### PR TITLE
Add Unity EditMode tests and documentation

### DIFF
--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ffe19fc9883d48768ec0c3cd0c208fc1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode.meta
+++ b/Assets/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 308562de934c49cfb2cb365c47c6e3fb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/EditMode/PriorityQueueTests.cs
+++ b/Assets/Tests/EditMode/PriorityQueueTests.cs
@@ -1,0 +1,17 @@
+using NUnit.Framework;
+
+public class PriorityQueueTests
+{
+    [Test]
+    public void EnqueueDequeue_MaintainsSortedOrder()
+    {
+        var pq = new PriorityQueue<int>((a, b) => a.CompareTo(b));
+        pq.Enqueue(5);
+        pq.Enqueue(1);
+        pq.Enqueue(3);
+
+        Assert.AreEqual(1, pq.Dequeue());
+        Assert.AreEqual(3, pq.Dequeue());
+        Assert.AreEqual(5, pq.Dequeue());
+    }
+}

--- a/Assets/Tests/EditMode/PriorityQueueTests.cs.meta
+++ b/Assets/Tests/EditMode/PriorityQueueTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7ad829e36f814419b2b204e6520ac176

--- a/Assets/Tests/EditMode/Tests.EditMode.asmdef
+++ b/Assets/Tests/EditMode/Tests.EditMode.asmdef
@@ -1,0 +1,6 @@
+{
+  "name": "Tests.EditMode",
+  "references": [
+    "Assembly-CSharp"
+  ]
+}

--- a/Assets/Tests/EditMode/Tests.EditMode.asmdef.meta
+++ b/Assets/Tests/EditMode/Tests.EditMode.asmdef.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 723e780f84884e9a823926d2f37c4b22

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Cowboya
+
+## Running Edit Mode Tests
+
+This project uses Unity's built in Test Framework. Edit mode tests live under
+`Assets/Tests/EditMode` and are compiled into their own assembly.
+
+### Using the Unity Editor
+
+1. Open the project in the Unity Editor.
+2. Open **Window > General > Test Runner**.
+3. Select the **Edit Mode** tab and click **Run All** to execute the tests.
+
+### Using the Command Line
+
+If you have the Unity Editor installed and available as `unity`, tests can be
+run non‑interactively:
+
+```bash
+unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit
+```
+
+The command will return a non‑zero exit code if any tests fail.

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b73bb5f86b9e49f58c5b4d4a1d84c040


### PR DESCRIPTION
## Summary
- add EditMode test assembly and a PriorityQueue unit test
- provide instructions on running EditMode tests

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a69d3415483249a419e75b26d88aa