### PR TITLE
Refactor waypoint architecture

### DIFF
--- a/Assets/Scripts/Game/SceneInitiator.cs
+++ b/Assets/Scripts/Game/SceneInitiator.cs
@@ -22,13 +22,17 @@ public class SceneInitiator : GameInitiator
     }
     private void BindOfObjects()
     {
-        factoryManager = Instantiate(factoryManager);
-        sceneControllerPrefab = Instantiate(sceneControllerPrefab);
-        gameUIViewModel = Instantiate(gameUIViewModel);
-        playerInitiator = Instantiate(playerInitiator);
-        enemiesSpawner = Instantiate(enemiesSpawner);
-        mapManager = Instantiate(mapManager);
-        waypointService = Instantiate(waypointService);
+        if (factoryManager == null) factoryManager = FindObjectOfType<FactoryManager>();
+        if (sceneControllerPrefab == null)
+        {
+            var sc = FindObjectOfType<SceneController>();
+            sceneControllerPrefab = sc != null ? sc.gameObject : null;
+        }
+        if (gameUIViewModel == null) gameUIViewModel = FindObjectOfType<GameUIViewModel>();
+        if (playerInitiator == null) playerInitiator = FindObjectOfType<PlayerSpawner>();
+        if (enemiesSpawner == null) enemiesSpawner = FindObjectOfType<EnemiesSpawner>();
+        if (mapManager == null) mapManager = FindObjectOfType<MapManager>();
+        if (waypointService == null) waypointService = FindObjectOfType<WaypointService>();
     }
 
     protected override void InitializeSceneSpecificObjects()

--- a/Assets/Scripts/Interfaces/IPOIReservationService.cs
+++ b/Assets/Scripts/Interfaces/IPOIReservationService.cs
@@ -1,0 +1,8 @@
+public interface IPOIReservationService
+{
+    RoomWaypoint GetLeastUsedFreeWorkPoint(RoomWaypoint exclude = null);
+    RoomWaypoint GetWorkOrRestPoint(RoomWaypoint exclude = null);
+    RoomWaypoint GetFirstRestPoint(RoomWaypoint exclude = null);
+    RoomWaypoint GetFirstFreeSecurityPoint();
+    void ReleasePOI(RoomWaypoint poi);
+}

--- a/Assets/Scripts/Interfaces/IPOIReservationService.cs.meta
+++ b/Assets/Scripts/Interfaces/IPOIReservationService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bfd6eb6ca3cf4e96aecdf2453a74af37

--- a/Assets/Scripts/Interfaces/IPathFinder.cs
+++ b/Assets/Scripts/Interfaces/IPathFinder.cs
@@ -1,0 +1,7 @@
+using System.Collections.Generic;
+
+public interface IPathFinder
+{
+    List<RoomWaypoint> FindWorldPath(RoomWaypoint start, RoomWaypoint end);
+    void BuildAllNeighbors();
+}

--- a/Assets/Scripts/Interfaces/IPathFinder.cs.meta
+++ b/Assets/Scripts/Interfaces/IPathFinder.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d8081fd26aa343ecafb74852e824ac5b

--- a/Assets/Scripts/Interfaces/IWaypointRegistry.cs
+++ b/Assets/Scripts/Interfaces/IWaypointRegistry.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+public interface IWaypointRegistry
+{
+    void RegisterRoomWaypoints(RoomManager room, IEnumerable<RoomWaypoint> waypoints);
+    void UnregisterRoomWaypoints(RoomManager room);
+    List<RoomWaypoint> GetAllWaypoints();
+    List<RoomWaypoint> GetActiveWaypoints();
+}

--- a/Assets/Scripts/Interfaces/IWaypointRegistry.cs.meta
+++ b/Assets/Scripts/Interfaces/IWaypointRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 24b271a7fdf54726a1df9c3eac356752

--- a/Assets/Scripts/Map/WaypointPathFinder.cs
+++ b/Assets/Scripts/Map/WaypointPathFinder.cs
@@ -2,15 +2,23 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
-public class WaypointPathFinder
+public class WaypointPathFinder : MonoBehaviour, IPathFinder
 {
-    private readonly WaypointRegistry registry;
-    private readonly List<INeighborConnector> connectors;
+    [SerializeField] private MonoBehaviour registryBehaviour;
+    private IWaypointRegistry registry;
+    private List<INeighborConnector> connectors;
 
-    public WaypointPathFinder(WaypointRegistry registry, params INeighborConnector[] connectors)
+    private void Awake()
     {
-        this.registry = registry;
-        this.connectors = connectors?.ToList() ?? new List<INeighborConnector>();
+        registry = registryBehaviour as IWaypointRegistry;
+        connectors = new List<INeighborConnector>
+        {
+            new AxisNeighborConnector(Axis.Horizontal, Bidirection.Both),
+            new AxisNeighborConnector(Axis.Vertical, Bidirection.Forward,
+                filter: wp => wp.type == WaypointType.LiftGoingUp),
+            new AxisNeighborConnector(Axis.Vertical, Bidirection.Forward, invert: true,
+                filter: wp => wp.type == WaypointType.LiftGoingDown)
+        };
     }
 
     public List<RoomWaypoint> FindWorldPath(RoomWaypoint start, RoomWaypoint end)

--- a/Assets/Scripts/Map/WaypointRegistry.cs
+++ b/Assets/Scripts/Map/WaypointRegistry.cs
@@ -1,7 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 
-public class WaypointRegistry
+public class WaypointRegistry : MonoBehaviour, IWaypointRegistry
 {
     private readonly Dictionary<RoomManager, List<RoomWaypoint>> roomWaypoints = new();
 

--- a/Assets/Scripts/Map/WaypointReservationService.cs
+++ b/Assets/Scripts/Map/WaypointReservationService.cs
@@ -2,16 +2,18 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
-public class WaypointReservationService
+public class WaypointReservationService : MonoBehaviour, IPOIReservationService
 {
+    [SerializeField] private MonoBehaviour registryBehaviour;
+    private IWaypointRegistry registry;
+
     private readonly HashSet<RoomWaypoint> _reservedWaypoints = new();
     private readonly Dictionary<RoomWaypoint, int> _workUsageCounts = new();
     private readonly Dictionary<RoomWaypoint, int> _securityUsageCounts = new();
-    private readonly WaypointRegistry registry;
 
-    public WaypointReservationService(WaypointRegistry registry)
+    private void Awake()
     {
-        this.registry = registry;
+        registry = registryBehaviour as IWaypointRegistry;
     }
 
     public RoomWaypoint GetLeastUsedFreeWorkPoint(RoomWaypoint exclude = null)

--- a/Assets/Scripts/Map/WaypointService.cs
+++ b/Assets/Scripts/Map/WaypointService.cs
@@ -8,24 +8,20 @@ public enum Bidirection { Both, Forward }
 
 public class WaypointService : MonoBehaviour, IWaypointService
 {
-    private WaypointRegistry registry = new();
-    private WaypointPathFinder pathFinder;
-    private WaypointReservationService reservationService;
+    [SerializeField] private MonoBehaviour registryBehaviour;
+    [SerializeField] private MonoBehaviour pathFinderBehaviour;
+    [SerializeField] private MonoBehaviour reservationServiceBehaviour;
+
+    private IWaypointRegistry registry;
+    private IPathFinder pathFinder;
+    private IPOIReservationService reservationService;
     private readonly HashSet<IRobotNavigationListener> robots = new();
 
     private void Awake()
     {
-        var connectors = new INeighborConnector[]
-        {
-            new AxisNeighborConnector(Axis.Horizontal, Bidirection.Both),
-            new AxisNeighborConnector(Axis.Vertical, Bidirection.Forward,
-                filter: wp => wp.type == WaypointType.LiftGoingUp),
-            new AxisNeighborConnector(Axis.Vertical, Bidirection.Forward, invert: true,
-                filter: wp => wp.type == WaypointType.LiftGoingDown)
-        };
-
-        pathFinder = new WaypointPathFinder(registry, connectors);
-        reservationService = new WaypointReservationService(registry);
+        registry = registryBehaviour as IWaypointRegistry;
+        pathFinder = pathFinderBehaviour as IPathFinder;
+        reservationService = reservationServiceBehaviour as IPOIReservationService;
     }
 
     #region Registration & Notification


### PR DESCRIPTION
## Summary
- add interfaces for waypoint components
- move registry, pathfinder and reservation logic into dedicated components
- refactor `WaypointService` to reference the new interfaces
- fetch components from the scene in `SceneInitiator`

## Testing
- `dotnet test -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9dfed23c8324889fd19068779964