### PR TITLE
Enable runtime binding for victory counters

### DIFF
--- a/Assets/Scripts/Setup/SceneBootstrapper.cs
+++ b/Assets/Scripts/Setup/SceneBootstrapper.cs
@@ -27,6 +27,7 @@ public class SceneBootstrapper : MonoBehaviour
         var sceneController = Instantiate(config.sceneControllerPrefab);
         var viewModel = Instantiate(config.gameUIViewModelPrefab);
         var victory = Instantiate(config.victorySetupPrefab);
+        viewModel.SetVictorySetup(victory);
         var saveService = Instantiate(config.saveServicePrefab);
 
         var initiator = sceneInitiator;

--- a/Assets/Scripts/UI/GameUIViewModel.cs
+++ b/Assets/Scripts/UI/GameUIViewModel.cs
@@ -16,6 +16,23 @@ public class GameUIViewModel : MonoBehaviour
         ui = GetComponent<UIDocument>().rootVisualElement;
     }
 
+    public void SetVictorySetup(VictorySetup setup)
+    {
+        victorySetup = setup;
+
+        if (ui == null)
+        {
+            ui = GetComponent<UIDocument>().rootVisualElement;
+        }
+
+        ui.Unbind();
+
+        if (victorySetup != null)
+        {
+            ui.Bind(victorySetup);
+        }
+    }
+
     public void SetPlayer(RobotStateController robot)
     {
         if (robot != null && robot.Stats != null)

--- a/Assets/UI Toolkit/GameHUDVisualTree.uxml
+++ b/Assets/UI Toolkit/GameHUDVisualTree.uxml
@@ -4,28 +4,28 @@
         <engine:VisualElement style="flex-grow: 1; width: auto; height: auto; flex-direction: row;">
             <engine:VisualElement name="VisualElement" class="bars-container horizontal-layout" style="width: 324px; justify-content: center; margin-bottom: 0; height: 89px; margin-left: 0; flex-direction: column;">
                 <engine:VisualElement name="VisualElement" class="bars-container horizontal-layout" style="width: 324px; justify-content: center; margin-bottom: 0; height: 53px; margin-left: 0;">
-                    <engine:IntegerField label="Robots saved" value="42" data-source="project://database/Assets/Scripts/ScriptObjects/VictorySetup.asset?fileID=11400000&amp;guid=71f325ff527d30649a5443ec4acf43a7&amp;type=2#VictorySetup" data-source-path="currentSaved" enabled="true" select-all-on-mouse-up="false" select-all-on-focus="false" select-word-by-double-click="false" select-line-by-triple-click="false" readonly="true">
+                    <engine:IntegerField label="Robots saved" value="42"  data-source-path="currentSaved" enabled="true" select-all-on-mouse-up="false" select-all-on-focus="false" select-word-by-double-click="false" select-line-by-triple-click="false" readonly="true">
                         <Bindings>
-                            <engine:DataBinding property="value" data-source-path="currentSaved" data-source="project://database/Assets/Scripts/ScriptObjects/VictorySetup.asset?fileID=11400000&amp;guid=71f325ff527d30649a5443ec4acf43a7&amp;type=2#VictorySetup" binding-mode="ToTarget" />
+                            <engine:DataBinding property="value" data-source-path="currentSaved"  binding-mode="ToTarget" />
                         </Bindings>
                     </engine:IntegerField>
                     <engine:TextField label="/" placeholder-text="filler text" style="width: 14px;" />
-                    <engine:IntegerField value="42" data-source="project://database/Assets/Scripts/ScriptObjects/VictorySetup.asset?fileID=11400000&amp;guid=71f325ff527d30649a5443ec4acf43a7&amp;type=2#VictorySetup" data-source-path="robotsSavedTarget" enabled="true" focusable="false" select-line-by-triple-click="false" select-word-by-double-click="false" select-all-on-focus="false" select-all-on-mouse-up="false" readonly="true">
+                    <engine:IntegerField value="42"  data-source-path="robotsSavedTarget" enabled="true" focusable="false" select-line-by-triple-click="false" select-word-by-double-click="false" select-all-on-focus="false" select-all-on-mouse-up="false" readonly="true">
                         <Bindings>
-                            <engine:DataBinding property="value" data-source-path="robotsSavedTarget" data-source="project://database/Assets/Scripts/ScriptObjects/VictorySetup.asset?fileID=11400000&amp;guid=71f325ff527d30649a5443ec4acf43a7&amp;type=2#VictorySetup" binding-mode="ToTarget" />
+                            <engine:DataBinding property="value" data-source-path="robotsSavedTarget"  binding-mode="ToTarget" />
                         </Bindings>
                     </engine:IntegerField>
                 </engine:VisualElement>
                 <engine:VisualElement name="VisualElement" enabled="true" class="bars-container horizontal-layout" style="width: 324px; justify-content: center; margin-bottom: 0; height: 53px; margin-left: 0;">
-                    <engine:IntegerField label="Robots killed" value="42" data-source="project://database/Assets/Scripts/ScriptObjects/VictorySetup.asset?fileID=11400000&amp;guid=71f325ff527d30649a5443ec4acf43a7&amp;type=2#VictorySetup" data-source-path="currentKilled" select-all-on-mouse-up="false" select-all-on-focus="false" select-line-by-triple-click="false" select-word-by-double-click="false" readonly="true">
+                    <engine:IntegerField label="Robots killed" value="42"  data-source-path="currentKilled" select-all-on-mouse-up="false" select-all-on-focus="false" select-line-by-triple-click="false" select-word-by-double-click="false" readonly="true">
                         <Bindings>
-                            <engine:DataBinding property="value" data-source-path="currentKilled" data-source="project://database/Assets/Scripts/ScriptObjects/VictorySetup.asset?fileID=11400000&amp;guid=71f325ff527d30649a5443ec4acf43a7&amp;type=2#VictorySetup" binding-mode="ToTarget" />
+                            <engine:DataBinding property="value" data-source-path="currentKilled"  binding-mode="ToTarget" />
                         </Bindings>
                     </engine:IntegerField>
                     <engine:TextField label="/" placeholder-text="filler text" style="width: 14px;" />
-                    <engine:IntegerField value="42" data-source="project://database/Assets/Scripts/ScriptObjects/VictorySetup.asset?fileID=11400000&amp;guid=71f325ff527d30649a5443ec4acf43a7&amp;type=2#VictorySetup" data-source-path="robotsKilledTarget" select-all-on-mouse-up="false" select-all-on-focus="false" select-word-by-double-click="false" select-line-by-triple-click="false" readonly="true">
+                    <engine:IntegerField value="42"  data-source-path="robotsKilledTarget" select-all-on-mouse-up="false" select-all-on-focus="false" select-word-by-double-click="false" select-line-by-triple-click="false" readonly="true">
                         <Bindings>
-                            <engine:DataBinding property="value" data-source-path="robotsKilledTarget" data-source="project://database/Assets/Scripts/ScriptObjects/VictorySetup.asset?fileID=11400000&amp;guid=71f325ff527d30649a5443ec4acf43a7&amp;type=2#VictorySetup" binding-mode="ToTarget" />
+                            <engine:DataBinding property="value" data-source-path="robotsKilledTarget"  binding-mode="ToTarget" />
                         </Bindings>
                     </engine:IntegerField>
                 </engine:VisualElement>


### PR DESCRIPTION
## Summary
- bind victory `ScriptableObject` to the HUD at runtime
- pass the `VictorySetup` instance from `SceneBootstrapper`
- remove hard‑coded data-source attributes from HUD UXML

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e662b07508324a998259d2d0a3864