### PR TITLE
Add boss spawn at end cell

### DIFF
--- a/Assets/Scripts/Game/SceneInitiator.cs
+++ b/Assets/Scripts/Game/SceneInitiator.cs
@@ -100,6 +100,7 @@ public class SceneInitiator : GameInitiator
             enemiesSpawner?.CreateWorkers(mapConfig.workersCount);
             enemiesSpawner?.CreateWorkersSpawner(mapConfig.blockedCount);
             enemiesSpawner?.CreateEnemies(mapConfig.enemiesCount);
+            enemiesSpawner?.CreateBoss();
         }
         enemiesSpawner?.SpreadEnemies();
     }

--- a/Assets/Scripts/Managers/EnemiesSpawner.cs
+++ b/Assets/Scripts/Managers/EnemiesSpawner.cs
@@ -83,16 +83,36 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner
     {
         EnemyRobotFactory enemyRobotFactory = new EnemyRobotFactory();
 
-        var boss = Instantiate(bossPrefab,
-                Vector3.zero,
-                Quaternion.identity,
-                enemiesParent);
+        var boss = Instantiate(
+            bossPrefab,
+            Vector3.zero,
+            Quaternion.identity,
+            enemiesParent);
 
         var robotState = boss.GetComponent<RobotStateController>();
         robotState.Stats = enemyRobotFactory.CreateRobot();
         robotState.Stats.RobotName = "BOSS 1";
-        boss.SetActive(false);
-        Debug.Log($"Boss created.");
+
+        // Position the boss at the end room center if available
+        RoomWaypoint endPoint = waypointService.GetEndPoint();
+        if (endPoint != null)
+        {
+            boss.transform.position = endPoint.WorldPos;
+        }
+        else
+        {
+            Debug.LogWarning("[EnemiesSpawner] No end room found for boss spawn.");
+        }
+
+        // Activate and initialise the boss AI
+        boss.SetActive(true);
+        var ec = boss.GetComponent<EnemyController>();
+        ec.Initialize(waypointService, waypointService, respawnService);
+        ec.SetSecurityGuardState();
+        if (endPoint != null)
+            ec.memory.SetLastVisitedPoint(endPoint);
+
+        Debug.Log("Boss created.");
     }
 
     public void CreateWorkersSpawner(int workersToSpawn)


### PR DESCRIPTION
## Summary
- spawn the boss in the end room via `EnemiesSpawner.CreateBoss`
- call `CreateBoss` during enemy initialization

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877d3a4e6b483249ad043dd66532801