### PR TITLE
Fix worker-machine reconnection logic

### DIFF
--- a/Assets/Scripts/EnemyAI/States/Worker_GoingToMachine.cs
+++ b/Assets/Scripts/EnemyAI/States/Worker_GoingToMachine.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+public class Worker_GoingToMachine : WorkerState
+{
+    private readonly FactoryMachine machine;
+    private RoomWaypoint targetPoint;
+    private bool hasArrived;
+
+    public Worker_GoingToMachine(EnemyWorkerController enemy,
+                                 WorkerStateMachine machineSM,
+                                 IWaypointService waypointService,
+                                 FactoryMachine machine)
+        : base(enemy, machineSM, waypointService)
+    {
+        this.machine = machine;
+    }
+
+    public override void EnterState()
+    {
+        enemy.workerState = WorkerStatus.GoingToWork;
+        targetPoint = waypointService.GetClosestWaypoint(machine.transform.position, includeUnavailable: true);
+        enemy.SetDestination(targetPoint, includeUnavailable: true);
+        hasArrived = false;
+    }
+
+    public override void UpdateState()
+    {
+        if (hasArrived) return;
+        if (enemy.HasArrivedAtDestination())
+        {
+            hasArrived = true;
+            enemy.SetMovement(0f);
+            enemy.SetVerticalMovement(0f);
+            enemy.memory.SetLastVisitedPoint(targetPoint);
+            waypointService.ReleasePOI(targetPoint);
+            machine.AttachRobot(enemy.gameObject);
+        }
+    }
+
+    public override void ExitState() { }
+}

--- a/Assets/Scripts/Machines/FactoryMachine.cs
+++ b/Assets/Scripts/Machines/FactoryMachine.cs
@@ -12,6 +12,7 @@ public class FactoryMachine : BaseMachine
     private MeshRenderer meshRenderer;
 
     public event Action<FactoryMachine, bool> OnMachineStateChanged;
+    public event Action<FactoryMachine, EnemyWorkerController> OnMachineTurningOff;
     private EnemyWorkerController currentWorker;
 
     public bool HasWorker => currentWorker != null;
@@ -35,9 +36,11 @@ public class FactoryMachine : BaseMachine
     {
         if (!isOn) return;
         SendCurrentWorkerToRest();
+        OnMachineTurningOff?.Invoke(this, currentWorker);
         base.PowerOff();
         ApplyMaterial();
         OnMachineStateChanged?.Invoke(this, false);
+        currentWorker = null;
     }
 
     private void ApplyMaterial()
@@ -115,6 +118,13 @@ public class FactoryMachine : BaseMachine
             new Worker_IsWork(worker, worker.stateMachine, worker.waypointService));
     }
 
+    public void SendWorkerBackToWork(EnemyWorkerController worker)
+    {
+        if (worker == null) return;
+        worker.stateMachine.ChangeState(
+            new Worker_GoingToMachine(worker, worker.stateMachine, worker.waypointService, this));
+    }
+
     /// <summary>
     /// Sends the currently assigned worker to the rest station and clears the reference.
     /// </summary>
@@ -128,5 +138,6 @@ public class FactoryMachine : BaseMachine
         SendCurrentWorkerToRest();
         isOccupied = false;
         base.ReleaseRobot();
+        currentWorker = null;
     }
 }

--- a/Assets/Scripts/Machines/MachineWorkerManager.cs
+++ b/Assets/Scripts/Machines/MachineWorkerManager.cs
@@ -22,18 +22,21 @@ public class MachineWorkerManager : MonoBehaviour
         machines.Add(machine);
         reservationService?.RegisterMachine(machine, RobotRole.Worker);
         machine.OnMachineStateChanged += HandleMachineStateChanged;
+        machine.OnMachineTurningOff += HandleMachineTurningOff;
     }
     private void HandleMachineStateChanged(FactoryMachine machine, bool isOn)
     {
         if (isOn)
             OnMachineTurnedOn(machine);
-        else
-            OnMachineTurnedOff(machine);
     }
 
-    private void OnMachineTurnedOff(FactoryMachine machine)
+    private void HandleMachineTurningOff(FactoryMachine machine, EnemyWorkerController worker)
     {
-        var worker = machine.CurrentWorker;
+        OnMachineTurnedOff(machine, worker);
+    }
+
+    private void OnMachineTurnedOff(FactoryMachine machine, EnemyWorkerController worker)
+    {
         if (worker == null)
             return;
 
@@ -52,8 +55,7 @@ public class MachineWorkerManager : MonoBehaviour
             {
                 var worker = pair.Key;
                 waitingWorkers.Remove(worker);
-                // Pseudocode: tell worker to resume work on this machine
-                AssignToFirstFreePointAvailable(worker);
+                machine.SendWorkerBackToWork(worker);
             }
         }
     }

--- a/Assets/Scripts/Machines/RestingMachine.cs
+++ b/Assets/Scripts/Machines/RestingMachine.cs
@@ -11,6 +11,7 @@ public class RestingMachine : BaseMachine
     private EnemyWorkerController currentWorker;
 
     public event Action<RestingMachine, bool> OnMachineStateChanged;
+    public event Action<RestingMachine, EnemyWorkerController> OnMachineTurningOff;
     protected override void Awake()
     {
         base.Awake();
@@ -37,9 +38,11 @@ public class RestingMachine : BaseMachine
     {
         if (!isOn) return;
         SendCurrentWorkerToWork();
+        OnMachineTurningOff?.Invoke(this, currentWorker);
         base.PowerOff();
         ApplyMaterial();
         OnMachineStateChanged?.Invoke(this, false);
+        currentWorker = null;
     }
 
     public override void AttachRobot(GameObject robot)
@@ -64,6 +67,7 @@ public class RestingMachine : BaseMachine
         SendCurrentWorkerToWork();
         isOccupied = false;
         base.ReleaseRobot();
+        currentWorker = null;
     }
 
     private void SendWorkerToRest(EnemyWorkerController worker)

--- a/Assets/Scripts/Machines/SpawningMachine.cs
+++ b/Assets/Scripts/Machines/SpawningMachine.cs
@@ -10,6 +10,7 @@ public class SpawningMachine : BaseMachine
     private MeshRenderer meshRenderer;
 
     public event Action<SpawningMachine, bool> OnMachineStateChanged;
+    public event Action<SpawningMachine, EnemyWorkerController> OnMachineTurningOff;
 
     [Header("Spawning Settings")]
     [SerializeField] private float spawnInterval = 30f;
@@ -74,9 +75,11 @@ public class SpawningMachine : BaseMachine
 
         StopSpawning();
         SendWorkerToStart(currentWorker);
+        OnMachineTurningOff?.Invoke(this, currentWorker);
         base.PowerOff();
         ApplyMaterial();
         OnMachineStateChanged?.Invoke(this, false);
+        currentWorker = null;
     }
 
 
@@ -141,6 +144,7 @@ public class SpawningMachine : BaseMachine
         SendWorkerToStart(currentWorker);
         isOccupied = false;
         base.ReleaseRobot();
+        currentWorker = null;
     }
 
     private void TryStartSpawning()

--- a/Game.csproj
+++ b/Game.csproj
@@ -259,6 +259,7 @@
     <Compile Include="Assets\Scripts\Robots\Hinge2DIkSolver.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\Controllers\FollowPlayerTriggerHandler.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\States\Worker_GoingToLeastWorkedStation.cs" />
+    <Compile Include="Assets\Scripts\EnemyAI\States\Worker_GoingToMachine.cs" />
     <Compile Include="Assets\Scripts\FactoryCore\FactoryManager.cs" />
     <Compile Include="Assets\Scripts\Robots\GroundChecker.cs" />
     <Compile Include="Assets\Scripts\Machines\SpawningWorkerManager.cs" />


### PR DESCRIPTION
## Summary
- add `OnMachineTurningOff` event for machines
- clear `currentWorker` after events
- create `Worker_GoingToMachine` state so workers can return to their machine
- track departing workers in `MachineWorkerManager`
- send workers back to the same machine when it turns on

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888d8b5d3fc8324adb049574a689493