### PR TITLE
Fix GameHUD transform style

### DIFF
--- a/Assets/UI Toolkit/GameHUDVisualTree.uxml
+++ b/Assets/UI Toolkit/GameHUDVisualTree.uxml
@@ -52,6 +52,6 @@
         <engine:VisualElement style="flex-grow: 1; align-items: flex-start; justify-content: flex-end;">
             <engine:VisualElement name="miniMapPreview" class="grid-preview" style="height: 134px; width: 442px; margin-top: 0;" />
         </engine:VisualElement>
-        <engine:Label name="GameMessageLabel" style="position: absolute; bottom: 10px; left: 50%; transform: translateX(-50%); background-color: rgba(0,0,0,0.6); color: white; padding: 5px; unity-font-style: bold; display: none;" />
+        <engine:Label name="GameMessageLabel" style="position: absolute; bottom: 10px; left: 50%; transform: translate(-50%, 0%); background-color: rgba(0,0,0,0.6); color: white; padding: 5px; unity-font-style: bold; display: none;" />
     </engine:VisualElement>
 </engine:UXML>


### PR DESCRIPTION
## Summary
- fix warning in GameHUD UXML by using `translate` syntax

## Testing
- `python3 - <<'PY'
import xml.etree.ElementTree as ET
ET.parse('Assets/UI Toolkit/GameHUDVisualTree.uxml')
print('xml parse ok')
PY`
- `bash setup_env.sh` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688b402c2d548324bca7017247dacbb4