### PR TITLE
feat: add morality tracking system

### DIFF
--- a/Assets/Editor/UnitTests/FactoryManagerTests.cs
+++ b/Assets/Editor/UnitTests/FactoryManagerTests.cs
@@ -60,9 +60,12 @@ public class FactoryManagerTests
     {
         var vs = ScriptableObject.CreateInstance<VictorySetup>();
         typeof(FactoryManager).GetField("victorySetup", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(_factoryManager, vs);
+        var stats = new RobotStats();
+        typeof(FactoryManager).GetField("playerStats", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(_factoryManager, stats);
 
         _factoryManager.OnRobotSaved();
         Assert.AreEqual(1, vs.currentSaved);
+        Assert.AreEqual(1f, stats.Morality);
     }
 
     [Test]
@@ -70,9 +73,12 @@ public class FactoryManagerTests
     {
         var vs = ScriptableObject.CreateInstance<VictorySetup>();
         typeof(FactoryManager).GetField("victorySetup", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(_factoryManager, vs);
+        var stats = new RobotStats();
+        typeof(FactoryManager).GetField("playerStats", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(_factoryManager, stats);
 
         _factoryManager.OnRobotKilled();
         Assert.AreEqual(1, vs.currentKilled);
+        Assert.AreEqual(-1f, stats.Morality);
     }
 
     private class DummyGridBuilder : IGridBuilder

--- a/Assets/Scripts/FactoryCore/FactoryManager.cs
+++ b/Assets/Scripts/FactoryCore/FactoryManager.cs
@@ -21,6 +21,7 @@ public class FactoryManager : MonoBehaviour, IFactoryManager
     private MapManager mapManager;
     private IWaypointService waypointService;
     private VictorySetup victorySetup;
+    private RobotStats playerStats;
 
     public GameObject playerInstance { get; private set; }
     public Transform playerHeadTransform { get; private set; } // Head inside WholeBody
@@ -85,12 +86,19 @@ public class FactoryManager : MonoBehaviour, IFactoryManager
         {
             Debug.LogError("FactoryManager: Player head transform is null.");
         }
+        var controller = playerInstance.GetComponent<RobotStateController>();
+        if (controller != null)
+        {
+            playerStats = controller.Stats;
+            controller.OnStateChanged += HandlePlayerStateChange;
+        }
     }
 
     public void OnRobotSaved()
     {
         victorySetup.currentSaved++;
         Debug.Log("Robot SAVED");
+        playerStats?.UpdateMorality(1f);
         // Optionally: Check for victory condition here
         if (victorySetup.currentSaved >= victorySetup.robotsSavedTarget)
         {
@@ -102,7 +110,16 @@ public class FactoryManager : MonoBehaviour, IFactoryManager
     {
         victorySetup.currentKilled++;
         Debug.Log("Robot KILLED");
+        playerStats?.UpdateMorality(-1f);
         // Optionally: Check for victory condition here
+    }
+
+    private void HandlePlayerStateChange(RobotState newState)
+    {
+        if (newState == RobotState.Dead)
+        {
+            playerStats?.ResetMorality();
+        }
     }
 
 }

--- a/Assets/Scripts/Player/Data/PlayerStats.cs
+++ b/Assets/Scripts/Player/Data/PlayerStats.cs
@@ -14,6 +14,7 @@ public class RobotStats
     public float AttackEnergyCost = 1f;
     public event Action OnHealthChanged;
     public event Action OnEnergyChanged;
+    public event Action OnMoralityChanged;
     public bool AbleToAttack => CurrentEnergy >= AttackEnergyCost;
     public float Morality { get; set; } = 0f;
     public List<Module> Modules { get; set; } = new List<Module>();
@@ -53,5 +54,15 @@ public class RobotStats
         OnHealthChanged?.Invoke();
     }
 
+    public void UpdateMorality(float delta)
+    {
+        Morality += delta;
+        OnMoralityChanged?.Invoke();
+    }
 
+    public void ResetMorality()
+    {
+        Morality = 0f;
+        OnMoralityChanged?.Invoke();
+    }
 }

--- a/Assets/Scripts/UI/GameUIViewModel.cs
+++ b/Assets/Scripts/UI/GameUIViewModel.cs
@@ -57,6 +57,7 @@ public class GameUIViewModel : MonoBehaviour
             // Subscribe to PlayerStats events
             robotInfo.OnEnergyChanged += UpdateEnergyBar;
             robotInfo.OnHealthChanged += UpdateHealthBar;
+            robotInfo.OnMoralityChanged += UpdateMoralityLabel;
 
             // Listen for player state changes
             robotBehaviour.OnStateChanged += HandleRobotStateChange;
@@ -64,6 +65,7 @@ public class GameUIViewModel : MonoBehaviour
             // Initial UI update
             UpdateEnergyBar();
             UpdateHealthBar();
+            UpdateMoralityLabel();
 
             Debug.Log("Health and energy bars bound to PlayerStateController.");
         }
@@ -78,6 +80,15 @@ public class GameUIViewModel : MonoBehaviour
         if (newState == RobotState.Dead)
         {
             MessageService.Instance?.ShowMessage(GameMessages.System.GameOver);
+        }
+    }
+
+    private void UpdateMoralityLabel()
+    {
+        if (robotBehaviour != null && robotBehaviour.Stats != null)
+        {
+            int currentMorality = Mathf.RoundToInt(robotBehaviour.Stats.Morality);
+            ui.Q<Label>("moralityLabel").text = $"Morality: {currentMorality}";
         }
     }
     private void UpdateEnergyBar()
@@ -135,6 +146,10 @@ public class GameUIViewModel : MonoBehaviour
         if (robotBehaviour != null)
         {
             robotBehaviour.OnStateChanged -= HandleRobotStateChange;
+            if (robotBehaviour.Stats != null)
+            {
+                robotBehaviour.Stats.OnMoralityChanged -= UpdateMoralityLabel;
+            }
         }
     }
 

--- a/Assets/UI Toolkit/GameHUDVisualTree.uxml
+++ b/Assets/UI Toolkit/GameHUDVisualTree.uxml
@@ -53,5 +53,6 @@
             <engine:VisualElement name="miniMapPreview" class="grid-preview" style="height: 134px; width: 442px; margin-top: 0;" />
         </engine:VisualElement>
         <engine:Label name="GameMessageLabel" style="position: absolute; bottom: 10px; left: 50%; transform: translate(-50%, 0%); background-color: rgba(0,0,0,0.6); color: white; padding: 5px; unity-font-style: bold; display: none;" />
+        <engine:Label name="moralityLabel" text="Morality: 0" style="position: absolute; top: 10px; right: 10px;" />
     </engine:VisualElement>
 </engine:UXML>


### PR DESCRIPTION
## Summary
- track player morality in RobotStats
- update morality when robots are saved or killed and reset on death
- show current morality in the HUD

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*
- `dotnet test UnitTests.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68906ed877888324825e07203c39103e