### PR TITLE
Enable allies for rescued robots

### DIFF
--- a/Assets/Resources/Prefabs/Robots/Worker (SecurityVariant).prefab
+++ b/Assets/Resources/Prefabs/Robots/Worker (SecurityVariant).prefab
@@ -123,6 +123,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 8465636778725824547, guid: c640cef127bd73741aa83f8927e08ed3, type: 3}
       insertIndex: -1
       addedObject: {fileID: 8796246411446560348}
+    - targetCorrespondingSourceObject: {fileID: 8465636778725824547, guid: c640cef127bd73741aa83f8927e08ed3, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2812764368535121391}
   m_SourcePrefab: {fileID: 100100000, guid: c640cef127bd73741aa83f8927e08ed3, type: 3}
 --- !u!4 &2524197683035446920 stripped
 Transform:
@@ -233,6 +236,7 @@ MonoBehaviour:
   arrivalThresholdY: 2
   deadZoneX: 5
   deadZoneY: 5
+  allyController: {fileID: 2812764368535121391}
   updateLoop: 0
 --- !u!95 &8796246411446560348
 Animator:
@@ -265,5 +269,23 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b174dc543db813e4ebf8a4dd68405936, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!114 &2812764368535121391
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7046974260770963575}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1429c14f0645339db44a757fbdebbe, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  bodyReference: {fileID: 5697296301688261397}
+  arrivalThresholdX: 2
+  arrivalThresholdY: 2
+  deadZoneX: 5
+  deadZoneY: 5
+  updateLoop: 0

--- a/Assets/Resources/Prefabs/Robots/Worker.prefab
+++ b/Assets/Resources/Prefabs/Robots/Worker.prefab
@@ -186,6 +186,7 @@ GameObject:
   - component: {fileID: 5579768388783519933}
   - component: {fileID: 574345331645963513}
   - component: {fileID: 6927027784846965603}
+  - component: {fileID: 2812764368535121390}
   m_Layer: 7
   m_Name: Worker
   m_TagString: Enemy
@@ -340,6 +341,7 @@ MonoBehaviour:
   arrivalThresholdY: 2
   deadZoneX: 1
   deadZoneY: 5
+  allyController: {fileID: 2812764368535121390}
   updateLoop: 0
 --- !u!114 &9201182588516880390
 MonoBehaviour:
@@ -2233,3 +2235,21 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 482515306807464926, guid: 5e0f120d833b85344af1ce7c845fbad9, type: 3}
   m_PrefabInstance: {fileID: 8750931863636473520}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &2812764368535121390
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9206399113533570876}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e1429c14f0645339db44a757fbdebbe, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  bodyReference: {fileID: 9206399112436540782}
+  arrivalThresholdX: 2
+  arrivalThresholdY: 2
+  deadZoneX: 5
+  deadZoneY: 5
+  updateLoop: 0

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
@@ -20,6 +20,7 @@ public class EnemyWorkerController : AnimatorBaseAgentController
     [SerializeField] private float deadZoneY = 5f;
 
     [SerializeField] private LowMoralityPlayerTriggerHandler lowMoralityTriggerHandler;
+    [SerializeField] private AllyController allyController;
     private FactoryMachine currentMachine;
 
     public WorkerStatus workerState { get; set; } = WorkerStatus.Idle;
@@ -43,6 +44,8 @@ public class EnemyWorkerController : AnimatorBaseAgentController
         robotBehaviour.OnStateChanged += HandleStateChange;
         if (lowMoralityTriggerHandler != null)
             lowMoralityTriggerHandler.OnLowMoralityPlayerDetected += HandleLowMoralityPlayerDetected;
+        if (allyController != null)
+            allyController.enabled = false;
     }
 
     public void Initialize(IWaypointQueries waypointQueries, IWaypointService waypointService, IRobotRespawnService respawnService)
@@ -60,6 +63,30 @@ public class EnemyWorkerController : AnimatorBaseAgentController
     public void SetWorkerSpawnerState()
     {
         IsWorkerSpawner = true;
+    }
+
+    /// <summary>
+    /// Converts this worker from an enemy into an ally.
+    /// </summary>
+    public void ConvertToAlly()
+    {
+        enabled = false;
+        if (stateMachine != null)
+            stateMachine.enabled = false;
+        if (lowMoralityTriggerHandler != null)
+            lowMoralityTriggerHandler.enabled = false;
+        if (robotBehaviour != null)
+            robotBehaviour.enabled = false;
+        if (memoryComponent != null)
+            memoryComponent.enabled = false;
+        var punchAttack = GetComponent<EnemyPunchAttack>();
+        if (punchAttack != null)
+            punchAttack.enabled = false;
+        var followHandler = GetComponent<FollowPlayerTriggerHandler>();
+        if (followHandler != null)
+            followHandler.enabled = false;
+        allyController.Initialize(waypointService);
+        allyController.enabled = true;
     }
 
     protected override void Update()

--- a/Assets/Scripts/EnemyAI/States/Worker_Saved.cs
+++ b/Assets/Scripts/EnemyAI/States/Worker_Saved.cs
@@ -9,6 +9,7 @@ public class Worker_Saved : WorkerState
     {
         enemy.workerState = WorkerStatus.Saved;
         enemy.SetMovement(0f);
+        enemy.ConvertToAlly();
         SceneController.instance?.RobotSaved();
     }
 


### PR DESCRIPTION
## Summary
- add AllyController support to EnemyWorkerController
- convert Worker robots to allies when saved
- hook up ally components on enemy prefabs

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890b78b26648324b6bec12d0f6bb0b9