### PR TITLE
Fix spawn order on enemy stuck handling

### DIFF
--- a/Assets/Scripts/EnemyAI/Core/RobotMemory.cs
+++ b/Assets/Scripts/EnemyAI/Core/RobotMemory.cs
@@ -44,6 +44,9 @@ public class RobotMemory : MonoBehaviour, IRobotMemory
     {
         Debug.Log($"[EnemyMemory] Enemy stuck at {controller.transform.position}. Requesting respawn.");
 
+        // Return the stuck enemy to the pool before requesting a respawn.
+        ObjectPool.Instance.Release(controller.gameObject);
+
         if (respawnService != null)
         {
             respawnService.RespawnWorker();
@@ -52,9 +55,6 @@ public class RobotMemory : MonoBehaviour, IRobotMemory
         {
             Debug.LogError("[EnemyMemory] Cannot respawn: service is null!");
         }
-
-        // Finally, return the stuck enemy to the pool:
-        ObjectPool.Instance.Release(controller.gameObject);
     }
 
     /// <summary>
@@ -65,6 +65,9 @@ public class RobotMemory : MonoBehaviour, IRobotMemory
     {
         Debug.Log($"[EnemyMemory] Boss stuck at {controller.transform.position}. Requesting respawn.");
 
+        // Return the stuck boss to the pool before requesting a respawn.
+        ObjectPool.Instance.Release(controller.gameObject);
+
         if (respawnService != null)
         {
             respawnService.RespawnBoss();
@@ -73,9 +76,6 @@ public class RobotMemory : MonoBehaviour, IRobotMemory
         {
             Debug.LogError("[EnemyMemory] Cannot respawn: service is null!");
         }
-
-        // Finally, return the stuck boss to the pool:
-        ObjectPool.Instance.Release(controller.gameObject);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- release stuck enemies to pool before spawning replacements

## Testing
- `bash ./setup_env.sh` *(fails: Package 'libasound2' has no installation candidate)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b237bffc832482747a9d9a2392fb