### PR TITLE
Handle enemy badge reassignment safely

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -73,9 +73,8 @@ public class EnemyController : PhysicsBaseAgentController
 
         if (securityBadgeSpawner)
         {
-            if (initialBadge != null)
-                Destroy(initialBadge.gameObject);
-            initialBadge = securityBadgeSpawner.SpawnBadge(bodyReference);
+            if (initialBadge == null)
+                initialBadge = securityBadgeSpawner.SpawnBadge(bodyReference);
         }
     }
 
@@ -166,6 +165,8 @@ public class EnemyController : PhysicsBaseAgentController
 
         if (dropContainer != null)
             initialBadge.transform.SetParent(dropContainer, true);
+
+        initialBadge = null;
     }
 
     public void OnBadgeStolen(GameObject player)


### PR DESCRIPTION
## Summary
- Avoid destroying existing enemy badge and only spawn when missing
- Clear reference to dropped badge after moving it to drop container

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b2690284832490808dd8da6aca64