### PR TITLE
Reset path follower on pool events

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -202,18 +202,23 @@ public class EnemyController : PhysicsBaseAgentController, IPooledObject
         pathFollower?.DrawGizmos();
     }
 
+    /// <summary>
+    /// Cleans up listeners and releases references when returned to the pool.
+    /// </summary>
     public void OnReleaseToPool()
     {
         if (pathFollower != null)
         {
-            if (stuckHandler != null)
-                pathFollower.OnStuck -= stuckHandler;
+            pathFollower.OnStuck -= stuckHandler;
             waypointNotifier?.Unsubscribe(pathFollower);
-            pathFollower = null;
-            stuckHandler = null;
         }
+        pathFollower = null;
+        stuckHandler = null;
     }
 
+    /// <summary>
+    /// Reinitializes required fields after being pulled from the pool.
+    /// </summary>
     public void OnAcquireFromPool()
     {
         if (pathFollower == null && waypointQueries != null)

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
@@ -199,18 +199,23 @@ public class EnemyWorkerController : AnimatorBaseAgentController, IPooledObject
         pathFollower?.DrawGizmos();
     }
 
+    /// <summary>
+    /// Cleans up listeners and references when returned to the pool.
+    /// </summary>
     public void OnReleaseToPool()
     {
         if (pathFollower != null)
         {
-            if (stuckHandler != null)
-                pathFollower.OnStuck -= stuckHandler;
+            pathFollower.OnStuck -= stuckHandler;
             waypointService?.Unsubscribe(pathFollower);
-            pathFollower = null;
-            stuckHandler = null;
         }
+        pathFollower = null;
+        stuckHandler = null;
     }
 
+    /// <summary>
+    /// Reinitializes state after the worker is pulled from the pool.
+    /// </summary>
     public void OnAcquireFromPool()
     {
         if (pathFollower == null && waypointQueries != null)


### PR DESCRIPTION
## Summary
- clean up path follower and event hooks when enemy controllers are returned to the pool
- reinitialize path followers when objects are acquired from the pool

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891dcc131fc8324926e76533ed70260