### PR TITLE
Reset RobotMemory when pooled

### DIFF
--- a/Assets/Scripts/EnemyAI/Core/RobotMemory.cs
+++ b/Assets/Scripts/EnemyAI/Core/RobotMemory.cs
@@ -118,8 +118,10 @@ public class RobotMemory : MonoBehaviour, IRobotMemory, IPooledObject
     /// </summary>
     public void OnReleaseToPool()
     {
-        ClearPlayerPosition();
-        ResetAttackMemory();
+        LastKnownPlayerPosition = Vector3.zero;
+        TimeSincePlayerLastSeen = 0f;
+        WasRecentlyAttacked = false;
+        TimeSinceLastAttack = 0f;
         LastVisitedPoint = null;
         respawnService = null;
     }
@@ -131,8 +133,9 @@ public class RobotMemory : MonoBehaviour, IRobotMemory, IPooledObject
     {
         TimeSincePlayerLastSeen = 0f;
         TimeSinceLastAttack = 0f;
-
         if (respawnService == null)
+        {
             respawnService = GetComponent<IRobotRespawnService>();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- reset RobotMemory fields when returning to pool
- reacquire respawn service when retrieved from pool

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891de5e895c832496d1323d36b9ecd8