### PR TITLE
Fix missing transforms for UI objects in MapGeneration scene

### DIFF
--- a/Assets/Scenes/MapGeneration.unity
+++ b/Assets/Scenes/MapGeneration.unity
@@ -1128,6 +1128,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
+  - component: {fileID: 865432109876543214}
   - component: {fileID: 865432109876543211}
   m_Layer: 0
   m_Name: PauseMenu
@@ -1136,6 +1137,21 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!4 &865432109876543214
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 865432109876543210}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &865432109876543211
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1156,6 +1172,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
+  - component: {fileID: 865432109876543215}
   - component: {fileID: 865432109876543213}
   m_Layer: 0
   m_Name: GameHUD
@@ -1164,6 +1181,21 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!4 &865432109876543215
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 865432109876543212}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &865432109876543213
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1183,5 +1215,5 @@ SceneRoots:
   m_Roots:
   - {fileID: 2946596400902040817}
   - {fileID: 650494369}
-  - {fileID: 865432109876543210}
-  - {fileID: 865432109876543212}
+  - {fileID: 865432109876543214}
+  - {fileID: 865432109876543215}


### PR DESCRIPTION
## Summary
- restore Transform components for PauseMenu and GameHUD in MapGeneration scene
- update scene roots to reference the new transforms

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689266fe91588324b557d3ca4c611db3