### PR TITLE
Cache guard before firing power-off event

### DIFF
--- a/Assets/Scripts/Machines/SecurityMachine.cs
+++ b/Assets/Scripts/Machines/SecurityMachine.cs
@@ -38,12 +38,12 @@ public class SecurityMachine : BaseMachine
     public override void PowerOff()
     {
         if (!isOn) return;
+        var guard = currentGuard;
+        OnMachineTurningOff?.Invoke(this, guard);
         SendCurrentGuardToRest();
-        OnMachineTurningOff?.Invoke(this, currentGuard);
         base.PowerOff();
         ApplyMaterial();
         OnMachineStateChanged?.Invoke(this, false);
-        currentGuard = null;
     }
 
     public override void AttachRobot(GameObject robot)


### PR DESCRIPTION
## Summary
- cache current guard before notifying listeners and sending it to rest

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6892f223b1008324b0dd101a4630c532