### PR TITLE
Add delayed scene transition on player death

### DIFF
--- a/Assets/Scripts/UI/GameUIViewModel.cs
+++ b/Assets/Scripts/UI/GameUIViewModel.cs
@@ -111,7 +111,15 @@ public class GameUIViewModel : MonoBehaviour
         if (newState == RobotState.Dead)
         {
             MessageService.Instance?.ShowMessage(GameMessages.System.GameOver);
+            StartCoroutine(LoadSceneAfterDelay());
         }
+    }
+
+    private IEnumerator LoadSceneAfterDelay()
+    {
+        yield return new WaitForSeconds(2f);
+        string targetScene = RunProgressManager.Instance != null ? "GameOverScene" : "MenuScene";
+        SceneController.instance.LoadScene(targetScene);
     }
 
     private void UpdateMoralityLabel()


### PR DESCRIPTION
## Summary
- Show the game over message when the robot dies and schedule scene transition
- After a short delay, load GameOverScene if a run is active or MenuScene otherwise

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689309b51e6c8324bcea5bdac130ea6a