### PR TITLE
Ensure EventSystem in gameplay scenes

### DIFF
--- a/Assets/Scenes/MapGeneration.unity
+++ b/Assets/Scenes/MapGeneration.unity
@@ -1120,9 +1120,67 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 56073e0a8583fb143b33c102c62335b7, type: 3}
+--- !u!1001 &738167928
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4416345490926287791, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_Name
+      value: EventSystem
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 2946596400902040817}
   - {fileID: 650494369}
+  - {fileID: 738167928}

--- a/Assets/Scenes/SetupSandbox.unity
+++ b/Assets/Scenes/SetupSandbox.unity
@@ -361,6 +361,63 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &738167928
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4416345490926287791, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_Name
+      value: EventSystem
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -368,3 +425,4 @@ SceneRoots:
   - {fileID: 1127376336}
   - {fileID: 1322428932}
   - {fileID: 1780545997}
+  - {fileID: 738167928}

--- a/Assets/Scenes/TestingSceneBot.unity
+++ b/Assets/Scenes/TestingSceneBot.unity
@@ -435,6 +435,63 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f17e4881fdf8f54aa5e11ada3e901f0, type: 3}
+--- !u!1001 &738167928
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 99375394658381250, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4416345490926287791, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
+      propertyPath: m_Name
+      value: EventSystem
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f0ca364be76020d4aaa0bbb596cc1b71, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -443,3 +500,4 @@ SceneRoots:
   - {fileID: 1693213631}
   - {fileID: 586899835}
   - {fileID: 1911094864}
+  - {fileID: 738167928}


### PR DESCRIPTION
## Summary
- add EventSystem prefab with InputSystemUIInputModule to MapGeneration, SetupSandbox, and TestingSceneBot scenes
- register new EventSystem roots in each scene

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893498ff8a4832488473b1b54c5d745