### PR TITLE
Fix pause menu null reference handling

### DIFF
--- a/Assets/Scripts/UI/PauseController.CS
+++ b/Assets/Scripts/UI/PauseController.CS
@@ -34,9 +34,22 @@ public class PauseController : MonoBehaviour
 
     private void OnEnable()
     {
+        if (_pauseActionRef == null)
+        {
+            Debug.LogError("PauseController: Pause action reference is missing.");
+            enabled = false;
+            return;
+        }
+
         _pauseAction = _pauseActionRef.action;
         _pauseAction.performed += OnPausePerformed;
         _pauseAction.Enable();
+
+        if (_pauseUI == null)
+        {
+            Debug.LogError("PauseController: PauseMenuUI reference is missing.");
+            return;
+        }
 
         _pauseUI.OnResumeClicked += TogglePause;
         _pauseUI.OnRestartClicked += RestartRun;
@@ -51,9 +64,12 @@ public class PauseController : MonoBehaviour
             _pauseAction.Disable();
         }
 
-        _pauseUI.OnResumeClicked -= TogglePause;
-        _pauseUI.OnRestartClicked -= RestartRun;
-        _pauseUI.OnMainMenuClicked -= GoToMainMenu;
+        if (_pauseUI != null)
+        {
+            _pauseUI.OnResumeClicked -= TogglePause;
+            _pauseUI.OnRestartClicked -= RestartRun;
+            _pauseUI.OnMainMenuClicked -= GoToMainMenu;
+        }
     }
 
     private void OnDestroy() => OnDisable();   // même nettoyage
@@ -64,6 +80,9 @@ public class PauseController : MonoBehaviour
     {
         _isPaused = !_isPaused;
         Time.timeScale = _isPaused ? 0 : 1;
+
+        if (_pauseUI == null)
+            return;
 
         if (_isPaused)
             _pauseUI.Show();

--- a/Assets/Scripts/UI/PauseMenuUI.cs
+++ b/Assets/Scripts/UI/PauseMenuUI.cs
@@ -17,12 +17,40 @@ public class PauseMenuUI : MonoBehaviour
     void Awake()
     {
         _uiDoc = GetComponent<UIDocument>();
+        if (_uiDoc == null)
+        {
+            Debug.LogError("PauseMenuUI: UIDocument component is missing.");
+            enabled = false;
+            return;
+        }
+
+        if (layout == null)
+        {
+            Debug.LogError("PauseMenuUI: Layout is not assigned.");
+            enabled = false;
+            return;
+        }
+
         _uiDoc.visualTreeAsset = layout;
         _root = _uiDoc.rootVisualElement;
 
-        _root.Q<Button>("resumeButton").clicked        += () => OnResumeClicked?.Invoke();
-        _root.Q<Button>("restartButton").clicked       += () => OnRestartClicked?.Invoke();
-        _root.Q<Button>("mainMenuButton").clicked      += () => OnMainMenuClicked?.Invoke();
+        var resumeButton = _root.Q<Button>("resumeButton");
+        if (resumeButton != null)
+            resumeButton.clicked += () => OnResumeClicked?.Invoke();
+        else
+            Debug.LogError("PauseMenuUI: 'resumeButton' not found in layout.");
+
+        var restartButton = _root.Q<Button>("restartButton");
+        if (restartButton != null)
+            restartButton.clicked += () => OnRestartClicked?.Invoke();
+        else
+            Debug.LogError("PauseMenuUI: 'restartButton' not found in layout.");
+
+        var mainMenuButton = _root.Q<Button>("mainMenuButton");
+        if (mainMenuButton != null)
+            mainMenuButton.clicked += () => OnMainMenuClicked?.Invoke();
+        else
+            Debug.LogError("PauseMenuUI: 'mainMenuButton' not found in layout.");
 
         gameObject.SetActive(false);  // hide at start
     }


### PR DESCRIPTION
## Summary
- guard PauseController against missing input action and pause UI references
- validate layout and buttons in PauseMenuUI before registering callbacks

## Testing
- `unity -version` *(fails: command not found)*
- `apt-get install -y unity-editor` *(fails: Unable to locate package unity-editor)*

------
https://chatgpt.com/codex/tasks/task_e_689353385c78832489c67b3421909083