### PR TITLE
refactor: centralize HUD panel styling

### DIFF
--- a/Assets/Resources/Prefabs/UI/GameHUDVisualTree.uxml
+++ b/Assets/Resources/Prefabs/UI/GameHUDVisualTree.uxml
@@ -1,13 +1,13 @@
 <engine:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:engine="UnityEngine.UIElements" xmlns:editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
     <Style src="project://database/Assets/Resources/Prefabs/UI/GameUIStyles.uss?fileID=7433441132597879392&amp;guid=183c87636ad119f469e7c4126c120d04&amp;type=3#GameUIStyles" />
-    <engine:VisualElement name="PauseMenu" enabled="true" focusable="false" class="pause-menu" style="margin-left: 0; background-color: rgba(0, 0, 0, 0.68); overflow: visible; visibility: visible; align-items: center; position: relative; flex-direction: column; flex-wrap: nowrap; justify-content: space-evenly; align-content: auto; -unity-font-style: bold; font-size: 25px; display: none;">
+    <engine:VisualElement name="PauseMenu" enabled="true" focusable="false" class="pause-menu hud-panel" style="overflow: visible; visibility: visible; align-items: center; position: relative; flex-direction: column; flex-wrap: nowrap; justify-content: space-evenly; align-content: auto; -unity-font-style: bold; font-size: 25px; display: none;">
         <engine:Button name="resumeButton" text="Resume" class="hud-button" />
         <engine:Button name="restartButton" text="Restart" class="hud-button" />
         <engine:Button name="mainMenuButton" text="Main Menu" class="hud-button" />
     </engine:VisualElement>
     <engine:VisualElement name="GameHUD" class="hud-root" style="flex-direction: column; flex-grow: 1; padding: 10px; justify-content: center; align-items: stretch; align-self: auto; align-content: auto; display: flex;">
         <engine:VisualElement style="flex-grow: 1; width: auto; height: auto; flex-direction: row;">
-            <engine:VisualElement name="VisualElement" class="bars-container horizontal-layout scoreboard" style="justify-content: center; margin-bottom: 0; margin-left: 0; flex-direction: column; background-color: rgba(236, 236, 236, 0.56);">
+            <engine:VisualElement name="VisualElement" class="bars-container horizontal-layout scoreboard hud-panel" style="justify-content: center;">
                 <engine:VisualElement name="VisualElement" class="bars-container horizontal-layout stat-row" style="justify-content: center; margin-bottom: 0; margin-left: 0;">
                     <engine:IntegerField label="Robots saved" value="42" data-source-path="currentSaved" enabled="true" select-all-on-mouse-up="false" select-all-on-focus="false" select-word-by-double-click="false" select-line-by-triple-click="false" readonly="true" data-source="project://database/Assets/Scripts/ScriptObjects/VictorySetup.asset?fileID=11400000&amp;guid=71f325ff527d30649a5443ec4acf43a7&amp;type=2#VictorySetup" focusable="false" class="hud-value-label">
                         <Bindings>
@@ -60,10 +60,10 @@
                 <engine:Label name="moralityLabel" text="Morality: 0" class="hud-label" style="position: absolute; top: 0; right: 0; width: auto; background-color: rgba(236, 236, 236, 0.58); left: 147px; bottom: 0;" />
             </engine:VisualElement>
         </engine:VisualElement>
-       <engine:VisualElement class="right-panel vertical-layout" style="height: 946px; padding: 0 20px 0 10px; width: 1567px; margin: 29px; align-items: flex-start; justify-content: flex-start;">
+       <engine:VisualElement class="right-panel vertical-layout hud-panel" style="height: 946px; width: 1567px; align-items: flex-start; justify-content: flex-start;">
             <engine:VisualElement name="miniMapPreview" class="grid-preview mini-map-preview" style="margin-top: 0;" />
         </engine:VisualElement>
-        <engine:VisualElement class="message-container" style="position: absolute; justify-content: center; align-items: center; display: flex;">
+        <engine:VisualElement class="message-container hud-panel" style="position: absolute; justify-content: center; align-items: center; display: flex;">
             <engine:Label name="GameMessageLabel" style="background-color: rgba(0, 0, 0, 0.6); color: white; padding: 5px; unity-font-style: bold; display: none; font-size: 28px;" />
         </engine:VisualElement>
     </engine:VisualElement>

--- a/Assets/Resources/Prefabs/UI/GameUIStyles.uss
+++ b/Assets/Resources/Prefabs/UI/GameUIStyles.uss
@@ -74,6 +74,14 @@
 }
 
 /* 6. Flexible HUD layout classes */
+.hud-panel {
+    background-color: rgba(0, 0, 0, 0.6);
+    padding: 10px;
+    margin: 0;
+    border-width: 1px;
+    border-color: #555555;
+    border-radius: 6px;
+}
 .hud-root {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
## Summary
- create reusable `.hud-panel` USS class for common panel styling
- update HUD UXML to use `.hud-panel` and drop inline background/padding/margin styles

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68946e20a7a0832489a3a3d585272d69