### PR TITLE
Reset robot state when acquired from pool

### DIFF
--- a/Assets/Scripts/RobotFactory/RobotStateController.cs
+++ b/Assets/Scripts/RobotFactory/RobotStateController.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
 using UnityEngine;
-public class RobotStateController : MonoBehaviour
+public class RobotStateController : MonoBehaviour, IPooledObject
 {
     public event Action<RobotState> OnStateChanged;
     public RobotState CurrentState { get; private set; } = RobotState.Alive;
@@ -108,4 +108,26 @@ public class RobotStateController : MonoBehaviour
         OnStateChanged?.Invoke(newState);
     }
 
+    /// <summary>
+    /// Resets the robot when it is acquired from the pool.
+    /// </summary>
+    public void OnAcquireFromPool()
+    {
+        bool stateChanged = CurrentState != RobotState.Alive;
+        CurrentState = RobotState.Alive;
+        Stats.CurrentHealth = Stats.MaxHealth;
+        Stats.CurrentEnergy = Stats.MaxEnergy;
+        if (stateChanged)
+        {
+            OnStateChanged?.Invoke(RobotState.Alive);
+        }
+    }
+
+    /// <summary>
+    /// Performs cleanup when the robot is released to the pool.
+    /// </summary>
+    public void OnReleaseToPool()
+    {
+        OnStateChanged = null;
+    }
 }


### PR DESCRIPTION
## Summary
- reset RobotStateController health, energy and state when pulled from pool
- clear RobotStateController event listeners when returned to pool

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*
- `rg -n "b174dc543db813e4ebf8a4dd68405936" Assets/Resources/Prefabs/Robots/Worker.prefab`
- `rg -n "b174dc543db813e4ebf8a4dd68405936" Assets/Resources/Prefabs/Robots/Bot5.prefab`
- `rg -n "b174dc543db813e4ebf8a4dd68405936" Assets/Resources/Prefabs/Robots/SecurityGuard.prefab`


------
https://chatgpt.com/codex/tasks/task_e_6895999962e88324ae596531df325250