### PR TITLE
Reset pooled object transforms before queueing

### DIFF
--- a/Assets/Scripts/EnemyAI/PooledEnemy.cs
+++ b/Assets/Scripts/EnemyAI/PooledEnemy.cs
@@ -56,6 +56,9 @@ public class PooledEnemy : MonoBehaviour, IPooledObject
             cachedTransforms[i].localPosition = defaultPositions[i];
             cachedTransforms[i].localRotation = defaultRotations[i];
         }
+
+        transform.localPosition = Vector3.zero;
+        transform.localRotation = Quaternion.identity;
     }
 
     public void OnAcquireFromPool()

--- a/Assets/Scripts/Managers/ObjectPool.cs
+++ b/Assets/Scripts/Managers/ObjectPool.cs
@@ -48,6 +48,8 @@ public class ObjectPool : SingletonBehaviour<ObjectPool>
 
         obj.SetActive(false);
         obj.transform.SetParent(transform, false);
+        obj.transform.localPosition = Vector3.zero;
+        obj.transform.localRotation = Quaternion.identity;
 
         if (instanceToPrefab.TryGetValue(obj, out var prefab) && pools.TryGetValue(prefab, out var queue))
         {


### PR DESCRIPTION
## Summary
- Ensure pooled objects are reset to zero position and rotation before returning to the pool
- Let pooled enemies clear their root transform on release

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68959c801e8c832482a886e897e6ef11