### PR TITLE
Refresh joint limiter references when pooling

### DIFF
--- a/Assets/Scripts/EnemyAI/PooledEnemy.cs
+++ b/Assets/Scripts/EnemyAI/PooledEnemy.cs
@@ -47,9 +47,9 @@ public class PooledEnemy : MonoBehaviour, IPooledObject
         }
 
         if (bodyJointLimiter != null)
-            bodyJointLimiter.enabled = true;
+            bodyJointLimiter.enabled = false;
         if (legJointLimiter != null)
-            legJointLimiter.enabled = true;
+            legJointLimiter.enabled = false;
 
         for (int i = 0; i < cachedTransforms.Length; i++)
         {
@@ -64,6 +64,18 @@ public class PooledEnemy : MonoBehaviour, IPooledObject
     public void OnAcquireFromPool()
     {
         jointBreaker?.RestoreAll();
+
+        if (bodyJointLimiter != null)
+        {
+            bodyJointLimiter.RefreshJoints();
+            bodyJointLimiter.enabled = true;
+        }
+
+        if (legJointLimiter != null)
+        {
+            legJointLimiter.RefreshJoints();
+            legJointLimiter.enabled = true;
+        }
 
         if (animator != null)
         {

--- a/Assets/Scripts/Robots/BodyJointLimiter.cs
+++ b/Assets/Scripts/Robots/BodyJointLimiter.cs
@@ -33,4 +33,20 @@ public class BodyJointLimiter : MonoBehaviour
         joint.limits = limits;
         joint.useLimits = true;
     }
+
+    /// <summary>
+    /// Reacquires hinge joint references after joints have been restored.
+    /// </summary>
+    public void RefreshJoints()
+    {
+        bodyJoint = FindJoint("Body");
+        torsoJoint = FindJoint("Torso");
+        lowTorsoJoint = FindJoint("LowTorso");
+    }
+
+    private HingeJoint2D FindJoint(string name)
+    {
+        var child = transform.Find(name);
+        return child != null ? child.GetComponent<HingeJoint2D>() : null;
+    }
 }

--- a/Assets/Scripts/Robots/LegJointLimiter.cs
+++ b/Assets/Scripts/Robots/LegJointLimiter.cs
@@ -32,4 +32,19 @@ public class LegJointLimiter : MonoBehaviour
         joint.limits = limits;
         joint.useLimits = true;
     }
+
+    /// <summary>
+    /// Reacquires leg hinge joint references after joints have been restored.
+    /// </summary>
+    public void RefreshJoints()
+    {
+        leftLegJoint = FindJoint("LeftLowLeg");
+        rightLegJoint = FindJoint("RightLowLeg");
+    }
+
+    private HingeJoint2D FindJoint(string name)
+    {
+        var child = transform.Find(name);
+        return child != null ? child.GetComponent<HingeJoint2D>() : null;
+    }
 }


### PR DESCRIPTION
## Summary
- refresh BodyJointLimiter and LegJointLimiter joint references when an enemy is pulled from the pool
- enable joint limiters only after their joints have been reassigned
- disable joint limiters when releasing to the pool to avoid running with stale references

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895ab1f1d448324b99c785e3a3ec569