### PR TITLE
Attach PooledEnemy to robot prefabs

### DIFF
--- a/Assets/Resources/Prefabs/Robots/Bot5.prefab
+++ b/Assets/Resources/Prefabs/Robots/Bot5.prefab
@@ -5132,6 +5132,7 @@ GameObject:
   - component: {fileID: 6603793096190714630}
   - component: {fileID: 9062504079035036979}
   - component: {fileID: 3224323752040795107}
+  - component: {fileID: 317205533927771976}
   m_Layer: 6
   m_Name: Bot5
   m_TagString: Player
@@ -5436,6 +5437,24 @@ MonoBehaviour:
   rightHand: {fileID: 7014825927884115475}
   throwStrength: 5
   inputSource: {fileID: 9062504079035036979}
+--- !u!114 &317205533927771976
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9206399113533570876}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2b34410077004bb9b5d8e80a3866eb09, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  bodyJointLimiter: {fileID: 6603793096190714630}
+  legJointLimiter: {fileID: 3067009131450268787}
+  animator: {fileID: 0}
+  stateMachine: {fileID: 0}
+  robotStateController: {fileID: 340242974285803334}
+  jointBreaker: {fileID: 8027441940180791310}
 --- !u!1 &9206399113579118250
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Robots/SecurityGuard.prefab
+++ b/Assets/Resources/Prefabs/Robots/SecurityGuard.prefab
@@ -4384,6 +4384,7 @@ GameObject:
   - component: {fileID: 4282379396995134653}
   - component: {fileID: 4039218795842909479}
   - component: {fileID: 8821255494166107071}
+  - component: {fileID: 356648147594604746}
   m_Layer: 7
   m_Name: SecurityGuard
   m_TagString: Enemy
@@ -4679,6 +4680,24 @@ MonoBehaviour:
   energyCostPerJump: 3
   waitStep: 1
   timeout: 0.5
+--- !u!114 &356648147594604746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8465636778725824547}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2b34410077004bb9b5d8e80a3866eb09, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  bodyJointLimiter: {fileID: 4282379396995134653}
+  legJointLimiter: {fileID: 4923068343172411815}
+  animator: {fileID: 0}
+  stateMachine: {fileID: 1327797449943358064}
+  robotStateController: {fileID: 7891739421741480506}
+  jointBreaker: {fileID: 1510882133398777467}
 --- !u!1 &8491232064010109857
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Robots/Worker.prefab
+++ b/Assets/Resources/Prefabs/Robots/Worker.prefab
@@ -188,6 +188,7 @@ GameObject:
   - component: {fileID: 6927027784846965603}
   - component: {fileID: 1652121089499442319}
   - component: {fileID: 4920133160292708415}
+  - component: {fileID: 681138149407633311}
   m_Layer: 7
   m_Name: Worker
   m_TagString: Enemy
@@ -465,6 +466,24 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   detectZone: {fileID: 9152245780975195678}
   radius: 20
+--- !u!114 &681138149407633311
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9206399113533570876}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2b34410077004bb9b5d8e80a3866eb09, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  bodyJointLimiter: {fileID: 0}
+  legJointLimiter: {fileID: 6927027784846965603}
+  animator: {fileID: 3831158568374747867}
+  stateMachine: {fileID: 0}
+  robotStateController: {fileID: 340242974285803334}
+  jointBreaker: {fileID: 574345331645963513}
 --- !u!1001 &446331177930903255
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- ensure robot prefabs reset joints when pulled from object pool by adding the PooledEnemy component

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895b0b3fefc8324aba9033c606215fe