### PR TITLE
Restore joints when pooled enemies respawn

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -221,6 +221,9 @@ public class EnemyController : PhysicsBaseAgentController, IPooledObject
     /// </summary>
     public void OnAcquireFromPool()
     {
+        var jointBreaker = GetComponent<JointBreaker>();
+        jointBreaker?.RestoreAll();
+
         if (pathFollower == null && waypointQueries != null)
         {
             SetupPathFollower();

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
@@ -218,6 +218,9 @@ public class EnemyWorkerController : AnimatorBaseAgentController, IPooledObject
     /// </summary>
     public void OnAcquireFromPool()
     {
+        var jointBreaker = GetComponent<JointBreaker>();
+        jointBreaker?.RestoreAll();
+
         if (pathFollower == null && waypointQueries != null)
         {
             SetupPathFollower();


### PR DESCRIPTION
## Summary
- Reconnect enemy joints when respawned from pool
- Continue to break joints on death without destroying components

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(command failed: command not found: unity)*

------
https://chatgpt.com/codex/tasks/task_e_6895b5f15ca08324a276fd68e0d06a83