### PR TITLE
Expand joint search and initialize on spawn

### DIFF
--- a/Assets/Scripts/Robots/BodyJointLimiter.cs
+++ b/Assets/Scripts/Robots/BodyJointLimiter.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using UnityEngine;
 
 public class BodyJointLimiter : MonoBehaviour
@@ -6,6 +7,11 @@ public class BodyJointLimiter : MonoBehaviour
     [SerializeField] private HingeJoint2D bodyJoint;
     [SerializeField] private HingeJoint2D torsoJoint;
     [SerializeField] private HingeJoint2D lowTorsoJoint;
+
+    private void Awake()
+    {
+        RefreshJoints();
+    }
 
     public void SetBodyRotationLimits(bool goingRight)
     {
@@ -46,7 +52,7 @@ public class BodyJointLimiter : MonoBehaviour
 
     private HingeJoint2D FindJoint(string name)
     {
-        var child = transform.Find(name);
-        return child != null ? child.GetComponent<HingeJoint2D>() : null;
+        return GetComponentsInChildren<HingeJoint2D>(true)
+            .FirstOrDefault(j => j.name == name);
     }
 }

--- a/Assets/Scripts/Robots/LegJointLimiter.cs
+++ b/Assets/Scripts/Robots/LegJointLimiter.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using UnityEngine;
 
 public class LegJointLimiter : MonoBehaviour
@@ -5,6 +6,11 @@ public class LegJointLimiter : MonoBehaviour
     [Header("Hinge joints des jambes")]
     public HingeJoint2D leftLegJoint;
     public HingeJoint2D rightLegJoint;
+
+    private void Awake()
+    {
+        RefreshJoints();
+    }
 
     public void SetLegRotationLimits(bool goingRight)
     {
@@ -44,7 +50,7 @@ public class LegJointLimiter : MonoBehaviour
 
     private HingeJoint2D FindJoint(string name)
     {
-        var child = transform.Find(name);
-        return child != null ? child.GetComponent<HingeJoint2D>() : null;
+        return GetComponentsInChildren<HingeJoint2D>(true)
+            .FirstOrDefault(j => j.name == name);
     }
 }


### PR DESCRIPTION
## Summary
- Ensure LegJointLimiter and BodyJointLimiter locate hinge joints anywhere in their hierarchy
- Refresh joint references on Awake to handle initial spawns

## Testing
- `bash setup_env.sh` *(failed: Package 'libasound2' has no installation candidate)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895be6aa3bc8324be15810f2f4e269c