### PR TITLE
Decouple head target from input system via look direction provider

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/AnimatorBaseAgentController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/AnimatorBaseAgentController.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 /// Base class for horizontal and vertical movement.
 /// Used by the player, enemies and allies.
 /// </summary>
-public abstract class AnimatorBaseAgentController : MonoBehaviour, IMover
+public abstract class AnimatorBaseAgentController : MonoBehaviour, IMover, ILookDirectionProvider
 {
     [Header("Movement Settings")]
     [SerializeField] protected float moveSpeed = 3f;
@@ -20,6 +20,12 @@ public abstract class AnimatorBaseAgentController : MonoBehaviour, IMover
     [SerializeField] private Transform points;
     [SerializeField] private Transform poles;
     private bool flipped = false;
+    private Vector2 lookDirection = Vector2.right;
+
+    /// <summary>
+    /// Gets the current look direction.
+    /// </summary>
+    public Vector2 LookDirection => lookDirection;
 
     protected bool isMoving;
     protected bool isVerticalMoving;
@@ -64,6 +70,8 @@ public abstract class AnimatorBaseAgentController : MonoBehaviour, IMover
     {
         this.direction = Mathf.Clamp(direction, -1f, 1f);
         isMoving = direction != 0;
+        if (!Mathf.Approximately(this.direction, 0f))
+            lookDirection = new Vector2(Mathf.Sign(this.direction), 0f);
     }
 
     /// <summary>

--- a/Assets/Scripts/EnemyAI/Controllers/PhysicsBaseAgentController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/PhysicsBaseAgentController.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 /// Base class for agents (player, enemies, allies) that handles movement, facing, and jumping using physical components.
 /// Uses RobotLocomotionController, and LegJointLimiter instead of Animator.
 /// </summary>
-public abstract class PhysicsBaseAgentController : MonoBehaviour, IMover
+public abstract class PhysicsBaseAgentController : MonoBehaviour, IMover, ILookDirectionProvider
 {
     [Header("Movement & Facing Modules")]
     [SerializeField] protected RobotLocomotionController locomotion;
@@ -14,6 +14,12 @@ public abstract class PhysicsBaseAgentController : MonoBehaviour, IMover
     protected float direction = 0f;
     protected float verticalDirection = 0f;
     protected bool flipped = false;
+    private Vector2 lookDirection = Vector2.right;
+
+    /// <summary>
+    /// Gets the current look direction.
+    /// </summary>
+    public Vector2 LookDirection => lookDirection;
 
     protected virtual void Awake()
     {
@@ -30,6 +36,8 @@ public abstract class PhysicsBaseAgentController : MonoBehaviour, IMover
     public virtual void SetMovement(float input)
     {
         direction = Mathf.Clamp(input, -1f, 1f);
+        if (!Mathf.Approximately(direction, 0f))
+            lookDirection = new Vector2(Mathf.Sign(direction), 0f);
         locomotion.HandleMovement(direction, flipped);
     }
 

--- a/Assets/Scripts/Interfaces/ILookDirectionProvider.cs
+++ b/Assets/Scripts/Interfaces/ILookDirectionProvider.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+/// <summary>
+/// Provides look direction information for characters.
+/// X &lt; 0 indicates left, X &gt; 0 indicates right.
+/// When idle, the last non-zero direction should be returned.
+/// </summary>
+public interface ILookDirectionProvider
+{
+    /// <summary>
+    /// Gets the current look direction.
+    /// </summary>
+    Vector2 LookDirection { get; }
+}

--- a/Assets/Scripts/Player/Controllers/PlayerMovementController.cs
+++ b/Assets/Scripts/Player/Controllers/PlayerMovementController.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 
 [RequireComponent(typeof(RobotLocomotionController))]
-public class PlayerMovementController : MonoBehaviour
+public class PlayerMovementController : MonoBehaviour, ILookDirectionProvider
 {
     [Header("Components")]
     [SerializeField] private RobotLocomotionController locomotion;
@@ -27,6 +27,13 @@ public class PlayerMovementController : MonoBehaviour
 
     [SerializeField] private EnergyBot energyBot;
 
+    private Vector2 lookDirection = Vector2.right;
+
+    /// <summary>
+    /// Gets the current look direction.
+    /// </summary>
+    public Vector2 LookDirection => lookDirection;
+
     private void Awake()
     {
         locomotion.OnJumpStarted += HandleJumpStart;
@@ -51,6 +58,9 @@ public class PlayerMovementController : MonoBehaviour
         {
             horizontalInput = input.Movement.x;
             verticalInput = input.Movement.y;
+
+            if (Mathf.Abs(horizontalInput) > 0.1f)
+                lookDirection = new Vector2(Mathf.Sign(horizontalInput), 0f);
         }
         TryFlip();
         CalculateAndApplyBodyRotation();

--- a/Assets/Scripts/RobotFactory/HeadTargetController.cs
+++ b/Assets/Scripts/RobotFactory/HeadTargetController.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.InputSystem;
 
 public class HeadTargetController : MonoBehaviour
 {
@@ -16,23 +15,38 @@ public class HeadTargetController : MonoBehaviour
     public float bendSpeed = 5f;
 
     private float currentBend = 0f;
-    private InputSystem_Actions controls;
-    [SerializeField] public bool isPlayerControlled = false;
+
+    [SerializeField] private MonoBehaviour directionProviderComponent;
+    private ILookDirectionProvider directionProvider;
+    private bool providerLogged;
 
     private void Awake()
     {
-        if (isPlayerControlled)
+        if (directionProviderComponent != null)
+            directionProvider = directionProviderComponent as ILookDirectionProvider;
+
+        if (directionProvider == null)
+            directionProvider = GetComponentInParent<ILookDirectionProvider>();
+
+        if (directionProvider == null && !providerLogged)
         {
-            controls = new InputSystem_Actions();
+            Debug.LogError("HeadTargetController: ILookDirectionProvider not found.", this);
+            providerLogged = true;
         }
     }
 
-    private void OnEnable() => controls.Enable();
-    private void OnDisable() => controls.Disable();
+    private void OnValidate()
+    {
+        if (directionProviderComponent == null)
+        {
+            var provider = GetComponentInParent<ILookDirectionProvider>();
+            directionProviderComponent = provider as MonoBehaviour;
+        }
+    }
 
     private void LateUpdate()
     {
-        if (!hips || !head || !locomotion) return;
+        if (!hips || !head || !locomotion || directionProvider == null) return;
 
         // 1. Mirror relative to the head position
         float headOffsetX = head.position.x - hips.position.x;
@@ -40,7 +54,7 @@ public class HeadTargetController : MonoBehaviour
         mirroredOffsetX = Mathf.Clamp(mirroredOffsetX, -maxMirrorOffset, maxMirrorOffset);
 
         // 2. Movement direction → bend offset (which way to lean)
-        float input = controls.Player.Move.ReadValue<Vector2>().x;
+        float input = directionProvider.LookDirection.x;
         float targetBend = Mathf.Clamp(input, -1f, 1f) * maxBendOffset;
 
         // Smooth interpolation to avoid jerks

--- a/Game.csproj
+++ b/Game.csproj
@@ -67,6 +67,7 @@
   <ItemGroup>
     <Compile Include="Assets\Scripts\EnemyAI\States\Enemy_AttackPlayer.cs" />
     <Compile Include="Assets\Scripts\Interfaces\IMover.cs" />
+    <Compile Include="Assets\Scripts\Interfaces\ILookDirectionProvider.cs" />
     <Compile Include="Assets\Scripts\Interfaces\IWaypointRegistry.cs" />
     <Compile Include="Assets\Scripts\Player\GrabSystem\GrabHandAttractor.cs" />
     <Compile Include="Assets\Scripts\Robots\AlternatingToggle.cs" />


### PR DESCRIPTION
## Summary
- introduce `ILookDirectionProvider` interface for sharing look direction
- implement interface in player and enemy controllers
- refactor `HeadTargetController` to consume provider instead of Input System

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68999d21c18483249aaf907cbfc27d98