### PR TITLE
Add player stat preservation to PlayerTemplate

### DIFF
--- a/Assets/Scripts/RobotFactory/PlayerTemplate.cs
+++ b/Assets/Scripts/RobotFactory/PlayerTemplate.cs
@@ -5,19 +5,29 @@ using UnityEngine;
 public class PlayerTemplate : RobotTemplate
 {
     private RobotStateController robotBehaviour;
+    private float currentHealth;
+    private float currentEnergy;
+    private float currentMorality;
+    private const float MinMorality = -10f;
+    private const float MaxMorality = 10f;
+
+    /// <summary>
+    /// Initializes and returns the player's state controller component.
+    /// </summary>
     public RobotStateController InitializePlayerStateController(GameObject robotInstance)
     {
-        // Get PlayerStateController component
         robotBehaviour = robotInstance.GetComponent<RobotStateController>();
         Debug.Log("PlayerStateController initialized.");
         return robotBehaviour;
     }
 
+    /// <summary>
+    /// Initializes the player's stats based on save data.
+    /// </summary>
     public RobotStats InitializePlayerStats(SaveData saveData)
     {
-        // Use factory to create Robot instance
         PlayerRobotFactory playerFactory =
-         new PlayerRobotFactory((int)saveData.MaxHealth, (int)saveData.MaxEnergy, 0, (int)saveData.AttackEnergyCost);
+            new PlayerRobotFactory((int)saveData.MaxHealth, (int)saveData.MaxEnergy, 0, (int)saveData.AttackEnergyCost);
 
         robotBehaviour.Stats = playerFactory.CreateRobot();
         Debug.Log("PlayerStats initialized with health: " + robotBehaviour.Stats.CurrentHealth
@@ -27,4 +37,46 @@ public class PlayerTemplate : RobotTemplate
         return robotBehaviour.Stats;
     }
 
+    /// <summary>
+    /// Captures current robot stats from the active player.
+    /// </summary>
+    public void CaptureStats(RobotStats source)
+    {
+        if (source == null)
+        {
+            return;
+        }
+
+        currentHealth = Mathf.Clamp(source.CurrentHealth, 0f, source.MaxHealth);
+        currentEnergy = Mathf.Clamp(source.CurrentEnergy, 0f, source.MaxEnergy);
+        currentMorality = Mathf.Clamp(source.Morality, MinMorality, MaxMorality);
+    }
+
+    /// <summary>
+    /// Applies stored stats to the target player.
+    /// </summary>
+    public void ApplyStats(RobotStats target)
+    {
+        if (target == null)
+        {
+            return;
+        }
+
+        target.CurrentHealth = Mathf.Clamp(currentHealth, 0f, target.MaxHealth);
+        target.CurrentEnergy = Mathf.Clamp(currentEnergy, 0f, target.MaxEnergy);
+        target.Morality = Mathf.Clamp(currentMorality, MinMorality, MaxMorality);
+        target.OnHealthChanged?.Invoke();
+        target.OnEnergyChanged?.Invoke();
+        target.OnMoralityChanged?.Invoke();
+    }
+
+    /// <summary>
+    /// Resets the stored stats to default values.
+    /// </summary>
+    public void ResetStats()
+    {
+        currentHealth = 0f;
+        currentEnergy = 0f;
+        currentMorality = 0f;
+    }
 }


### PR DESCRIPTION
## Summary
- store player health, energy and morality between spawns
- add helpers to capture, apply and reset cached stats

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found: unity)*

------
https://chatgpt.com/codex/tasks/task_e_6899a170e5048324b9316971e39323f5