### PR TITLE
Capture player stats and clear hands before advancing levels

### DIFF
--- a/Assets/Scripts/Game/LevelEndTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndTrigger.cs
@@ -2,10 +2,25 @@ using UnityEngine;
 
 public class LevelEndTrigger : MonoBehaviour
 {
+    [SerializeField] private PlayerTemplate playerTemplate;
+
     private void OnTriggerEnter2D(Collider2D other)
     {
         if (other.CompareTag("Player") && RunProgressManager.Instance != null)
         {
+            RobotStateController controller = other.GetComponent<RobotStateController>();
+            GrabSystem grabSystem = other.GetComponent<GrabSystem>();
+
+            if (grabSystem != null)
+            {
+                grabSystem.ClearHands();
+            }
+
+            if (playerTemplate != null && controller != null)
+            {
+                playerTemplate.CaptureStats(controller.Stats);
+            }
+
             RunProgressManager.Instance.LoadNextLevel();
         }
     }

--- a/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
@@ -5,6 +5,7 @@ public class LevelEndVictoryTrigger : MonoBehaviour
 {
     [SerializeField] private DoorController doorNext;
     [SerializeField] private VictorySetup victorySetup;
+    [SerializeField] private PlayerTemplate playerTemplate;
 
     private bool isVictoryDoor = false;
 
@@ -21,6 +22,19 @@ public class LevelEndVictoryTrigger : MonoBehaviour
                 || victorySetup.currentSaved >= victorySetup.robotsSavedTarget;
             if (isVictoryDoor && isVictory && collision.CompareTag("Player"))
             {
+                RobotStateController controller = collision.GetComponent<RobotStateController>();
+                GrabSystem grabSystem = collision.GetComponent<GrabSystem>();
+
+                if (grabSystem != null)
+                {
+                    grabSystem.ClearHands();
+                }
+
+                if (playerTemplate != null && controller != null)
+                {
+                    playerTemplate.CaptureStats(controller.Stats);
+                }
+
                 RunProgressManager.Instance.LoadNextLevel();
             }
 

--- a/Assets/Scripts/Player/GrabSystem/GrabSystem.cs
+++ b/Assets/Scripts/Player/GrabSystem/GrabSystem.cs
@@ -56,6 +56,19 @@ public class GrabSystem : MonoBehaviour
             rightHeld.OnAttract(rightHand.transform.position);
     }
 
+    public void ClearHands()
+    {
+        if (leftHeld != null)
+        {
+            Release(leftHand, ref leftHeld);
+        }
+
+        if (rightHeld != null)
+        {
+            Release(rightHand, ref rightHeld);
+        }
+    }
+
     private void TryGrab(GrabHandAttractor hand, ref IGrabbable held)
     {
         if (hand == null || held != null) return;

--- a/Assets/Scripts/RobotFactory/PlayerTemplate.cs
+++ b/Assets/Scripts/RobotFactory/PlayerTemplate.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class PlayerTemplate : RobotTemplate
 {
     private RobotStateController robotBehaviour;
+    public RobotStats CapturedStats { get; private set; }
     public RobotStateController InitializePlayerStateController(GameObject robotInstance)
     {
         // Get PlayerStateController component
@@ -25,6 +26,11 @@ public class PlayerTemplate : RobotTemplate
         + " and attack energy cost: " + robotBehaviour.Stats.AttackEnergyCost);
 
         return robotBehaviour.Stats;
+    }
+
+    public void CaptureStats(RobotStats stats)
+    {
+        CapturedStats = stats;
     }
 
 }


### PR DESCRIPTION
## Summary
- Record player stats and drop held items before triggering level transitions
- Add ClearHands helper to GrabSystem to release objects
- Store captured player stats in PlayerTemplate for later use

## Testing
- `bash ./setup_env.sh` *(failed: Package 'libasound2' has no installation candidate)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(command not found: unity)*

------
https://chatgpt.com/codex/tasks/task_e_6899a1784ae08324a9a59a3e90fd9dad