### PR TITLE
Apply player stats before gameplay

### DIFF
--- a/Assets/Scripts/Player/Core/PlayerSpawner.cs
+++ b/Assets/Scripts/Player/Core/PlayerSpawner.cs
@@ -38,6 +38,8 @@ public class PlayerSpawner : MonoBehaviour, IPlayerSpawner
         // Setup behaviour and save-data info
         playerRobotBehaviour = playerTemplate.InitializePlayerStateController(playerInstance);
         playerRobotInfo = playerTemplate.InitializePlayerStats(saveService.CurrentSaveData);
+        // Apply stats before gameplay so HUD and AI use updated values
+        playerTemplate.ApplyStats(playerRobotInfo);
 
         // Locate "WholeBody" container
         Transform wholeBody = playerInstance.transform.Find("WholeBody");


### PR DESCRIPTION
## Summary
- Ensure PlayerSpawner applies loaded stats to the player template so HUD and AI start with correct values

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6899a3b9eeb08324ae2d1760746f987b