### PR TITLE
Use stat update methods in PlayerTemplate

### DIFF
--- a/Assets/Scripts/RobotFactory/PlayerTemplate.cs
+++ b/Assets/Scripts/RobotFactory/PlayerTemplate.cs
@@ -59,12 +59,13 @@ public class PlayerTemplate : RobotTemplate
             return;
         }
 
-        target.CurrentHealth = Mathf.Clamp(currentHealth, 0f, target.MaxHealth);
-        target.CurrentEnergy = Mathf.Clamp(currentEnergy, 0f, target.MaxEnergy);
-        target.Morality = Mathf.Clamp(currentMorality, MinMorality, MaxMorality);
-        target.OnHealthChanged?.Invoke();
-        target.OnEnergyChanged?.Invoke();
-        target.OnMoralityChanged?.Invoke();
+        float healthTarget = Mathf.Clamp(currentHealth, 0f, target.MaxHealth);
+        float energyTarget = Mathf.Clamp(currentEnergy, 0f, target.MaxEnergy);
+        float moralityTarget = Mathf.Clamp(currentMorality, MinMorality, MaxMorality);
+
+        target.UpdateHealth(healthTarget - target.CurrentHealth);
+        target.UpdateEnergy(energyTarget - target.CurrentEnergy);
+        target.UpdateMorality(moralityTarget - target.Morality);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Avoid manually invoking RobotStats events when applying stored stats
- Use UpdateHealth, UpdateEnergy, and UpdateMorality to apply changes

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899add21c348324919ce845b5e44cef