### PR TITLE
Gate player stat application behind capture check

### DIFF
--- a/Assets/Scripts/Player/Core/PlayerSpawner.cs
+++ b/Assets/Scripts/Player/Core/PlayerSpawner.cs
@@ -39,7 +39,10 @@ public class PlayerSpawner : MonoBehaviour, IPlayerSpawner
         playerRobotBehaviour = playerTemplate.InitializePlayerStateController(playerInstance);
         playerRobotInfo = playerTemplate.InitializePlayerStats(saveService.CurrentSaveData);
         // Apply stats before gameplay so HUD and AI use updated values
-        playerTemplate.ApplyStats(playerRobotInfo);
+        if (playerTemplate.HasCapturedStats)
+        {
+            playerTemplate.ApplyStats(playerRobotInfo);
+        }
 
         // Locate "WholeBody" container
         Transform wholeBody = playerInstance.transform.Find("WholeBody");

--- a/Assets/Scripts/RobotFactory/PlayerTemplate.cs
+++ b/Assets/Scripts/RobotFactory/PlayerTemplate.cs
@@ -8,6 +8,7 @@ public class PlayerTemplate : RobotTemplate
     private float currentHealth;
     private float currentEnergy;
     private float currentMorality;
+    private bool hasCapturedStats;
 
     private const float MinMorality = -100f;
     private const float MaxMorality = 100f;
@@ -47,6 +48,7 @@ public class PlayerTemplate : RobotTemplate
         currentHealth = Mathf.Clamp(source.CurrentHealth, 0f, source.MaxHealth);
         currentEnergy = Mathf.Clamp(source.CurrentEnergy, 0f, source.MaxEnergy);
         currentMorality = Mathf.Clamp(source.Morality, MinMorality, MaxMorality);
+        hasCapturedStats = true;
     }
 
     /// <summary>
@@ -54,7 +56,7 @@ public class PlayerTemplate : RobotTemplate
     /// </summary>
     public void ApplyStats(RobotStats target)
     {
-        if (target == null)
+        if (target == null || !hasCapturedStats)
         {
             return;
         }
@@ -76,5 +78,11 @@ public class PlayerTemplate : RobotTemplate
         currentHealth = 0f;
         currentEnergy = 0f;
         currentMorality = 0f;
+        hasCapturedStats = false;
     }
+
+    /// <summary>
+    /// Indicates whether stats have been captured for later application.
+    /// </summary>
+    public bool HasCapturedStats => hasCapturedStats;
 }


### PR DESCRIPTION
## Summary
- Track whether PlayerTemplate has captured stats and expose as a property
- Apply stored stats on spawn only when captured values exist

## Testing
- `bash setup_env.sh` *(fails: Package 'libasound2' has no installation candidate)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b2b9855c8324a2b092eeb590c4fd