### PR TITLE
Initialize player stats with current values

### DIFF
--- a/Assets/Scripts/RobotFactory/PlayerRobotFactory.cs
+++ b/Assets/Scripts/RobotFactory/PlayerRobotFactory.cs
@@ -5,24 +5,45 @@ using UnityEngine;
 // Player Robot Factory
 public class PlayerRobotFactory : RobotFactory
 {
+    private int currentHealth;
+    private int currentEnergy;
+
     public PlayerRobotFactory()
     {
         health = 100;
+        currentHealth = health;
         energy = 100;
-        energyAttackCost=5;
+        currentEnergy = energy;
+        energyAttackCost = 5;
         morality = 0;
     }
 
-    public PlayerRobotFactory(int healtFromSave, int energyFromSave, int moralityFromSave, int energyAttackCostFromSave)
+    public PlayerRobotFactory(
+        int currentHealthFromSave,
+        int maxHealthFromSave,
+        int currentEnergyFromSave,
+        int maxEnergyFromSave,
+        int moralityFromSave,
+        int energyAttackCostFromSave)
     {
-        health = healtFromSave;
-        energy = energyFromSave;
+        currentHealth = currentHealthFromSave;
+        health = maxHealthFromSave;
+        currentEnergy = currentEnergyFromSave;
+        energy = maxEnergyFromSave;
         morality = moralityFromSave;
         energyAttackCost = energyAttackCostFromSave;
     }
 
     public override RobotStats CreateRobot()
     {
-        return new RobotStats(health, health, energy, energy,energyAttackCost, morality, new List<Module>(modules), new List<Attack>(attacks));
+        return new RobotStats(
+            currentHealth,
+            health,
+            currentEnergy,
+            energy,
+            energyAttackCost,
+            morality,
+            new List<Module>(modules),
+            new List<Attack>(attacks));
     }
 }

--- a/Assets/Scripts/RobotFactory/PlayerTemplate.cs
+++ b/Assets/Scripts/RobotFactory/PlayerTemplate.cs
@@ -25,7 +25,13 @@ public class PlayerTemplate : RobotTemplate
     public RobotStats InitializePlayerStats(SaveData saveData)
     {
         PlayerRobotFactory playerFactory =
-            new PlayerRobotFactory((int)saveData.MaxHealth, (int)saveData.MaxEnergy, 0, (int)saveData.AttackEnergyCost);
+            new PlayerRobotFactory(
+                (int)saveData.CurrentHealth,
+                (int)saveData.MaxHealth,
+                (int)saveData.CurrentEnergy,
+                (int)saveData.MaxEnergy,
+                0,
+                (int)saveData.AttackEnergyCost);
 
         robotBehaviour.Stats = playerFactory.CreateRobot();
         Debug.Log("PlayerStats initialized with health: " + robotBehaviour.Stats.CurrentHealth


### PR DESCRIPTION
## Summary
- Pass current health and energy from SaveData to PlayerRobotFactory when initializing player stats
- Update PlayerRobotFactory to build RobotStats using separate current and max values for health and energy

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b3d18f348324ad33fe34055fd19a