### PR TITLE
Persist player health and energy stats in save data

### DIFF
--- a/Assets/Scripts/Player/Data/PlayerSaveService.cs
+++ b/Assets/Scripts/Player/Data/PlayerSaveService.cs
@@ -26,9 +26,11 @@ public class PlayerSaveService : MonoBehaviour, ISaveService
             CurrentSaveData = new SaveData(); // Ensure CurrentSaveData is not null before saving
         }
         RobotStateController robotBehaviour = runtimePlayerData.RobotGameObjectPrefab.GetComponent<RobotStateController>();
-        // CurrentSaveData.MaxHealth = robotBehaviour.Stats.MaxHealth;
-        // CurrentSaveData.MaxEnergy = robotBehaviour.Stats.MaxEnergy;
-        // CurrentSaveData.AttackEnergyCost = robotBehaviour.Stats.AttackEnergyCost;
+        CurrentSaveData.CurrentHealth = robotBehaviour.Stats.CurrentHealth;
+        CurrentSaveData.MaxHealth = robotBehaviour.Stats.MaxHealth;
+        CurrentSaveData.CurrentEnergy = robotBehaviour.Stats.CurrentEnergy;
+        CurrentSaveData.MaxEnergy = robotBehaviour.Stats.MaxEnergy;
+        CurrentSaveData.AttackEnergyCost = robotBehaviour.Stats.AttackEnergyCost;
         // CurrentSaveData.experience = runtimePlayerData.experience;
         // Map other fields as needed
 


### PR DESCRIPTION
## Summary
- Save current and maximum health and energy along with attack energy cost in `PlayerSaveService`
- Confirm player initialization uses these values to rebuild stats

## Testing
- `bash setup_env.sh` *(fails: Package 'libasound2' has no installation candidate)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(command not found: unity)*

------
https://chatgpt.com/codex/tasks/task_e_6899b48cc8b883248e9f3a969cfcc6e1