### PR TITLE
Save player state when completing levels

### DIFF
--- a/Assets/Scripts/Game/LevelEndTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndTrigger.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 public class LevelEndTrigger : MonoBehaviour
 {
     [SerializeField] private PlayerTemplate playerTemplate;
+    [SerializeField] private PlayerSaveService saveService;
 
     private void OnTriggerEnter2D(Collider2D other)
     {
@@ -19,6 +20,10 @@ public class LevelEndTrigger : MonoBehaviour
             if (playerTemplate != null && controller != null)
             {
                 playerTemplate.CaptureStats(controller.Stats);
+                if (saveService != null)
+                {
+                    saveService.SaveGame(controller);
+                }
             }
 
             RunProgressManager.Instance.LoadNextLevel();

--- a/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
@@ -6,6 +6,7 @@ public class LevelEndVictoryTrigger : MonoBehaviour
     [SerializeField] private DoorController doorNext;
     [SerializeField] private VictorySetup victorySetup;
     [SerializeField] private PlayerTemplate playerTemplate;
+    [SerializeField] private PlayerSaveService saveService;
 
     private bool isVictoryDoor = false;
 
@@ -33,6 +34,10 @@ public class LevelEndVictoryTrigger : MonoBehaviour
                 if (playerTemplate != null && controller != null)
                 {
                     playerTemplate.CaptureStats(controller.Stats);
+                    if (saveService != null)
+                    {
+                        saveService.SaveGame(controller);
+                    }
                 }
 
                 RunProgressManager.Instance.LoadNextLevel();

--- a/Assets/Scripts/Player/Data/PlayerSaveService.cs
+++ b/Assets/Scripts/Player/Data/PlayerSaveService.cs
@@ -21,16 +21,21 @@ public class PlayerSaveService : MonoBehaviour, ISaveService
     // Save the current save data to a file
     public void SaveGame()
     {
+        RobotStateController robotBehaviour = runtimePlayerData.RobotGameObjectPrefab.GetComponent<RobotStateController>();
+        SaveGame(robotBehaviour);
+    }
+
+    public void SaveGame(RobotStateController controller)
+    {
         if (CurrentSaveData == null)
         {
             CurrentSaveData = new SaveData(); // Ensure CurrentSaveData is not null before saving
         }
-        RobotStateController robotBehaviour = runtimePlayerData.RobotGameObjectPrefab.GetComponent<RobotStateController>();
-        CurrentSaveData.CurrentHealth = robotBehaviour.Stats.CurrentHealth;
-        CurrentSaveData.MaxHealth = robotBehaviour.Stats.MaxHealth;
-        CurrentSaveData.CurrentEnergy = robotBehaviour.Stats.CurrentEnergy;
-        CurrentSaveData.MaxEnergy = robotBehaviour.Stats.MaxEnergy;
-        CurrentSaveData.AttackEnergyCost = robotBehaviour.Stats.AttackEnergyCost;
+        CurrentSaveData.CurrentHealth = controller.Stats.CurrentHealth;
+        CurrentSaveData.MaxHealth = controller.Stats.MaxHealth;
+        CurrentSaveData.CurrentEnergy = controller.Stats.CurrentEnergy;
+        CurrentSaveData.MaxEnergy = controller.Stats.MaxEnergy;
+        CurrentSaveData.AttackEnergyCost = controller.Stats.AttackEnergyCost;
         // CurrentSaveData.experience = runtimePlayerData.experience;
         // Map other fields as needed
 

--- a/Assets/Scripts/Player/Interfaces/ISaveService.cs
+++ b/Assets/Scripts/Player/Interfaces/ISaveService.cs
@@ -4,6 +4,7 @@ public interface ISaveService
 {
     SaveData CurrentSaveData { get; }
     void SaveGame();
+    void SaveGame(RobotStateController controller);
     void LoadGame();
     void ResetSaveData();
 }


### PR DESCRIPTION
## Summary
- add PlayerSaveService references to level-end triggers
- persist player stats before loading the next level
- extend save service interface to accept a controller

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899ba83706883249c6eaf1dac728009