### PR TITLE
Reuse existing PlayerSaveService

### DIFF
--- a/Assets/Scripts/Setup/SceneBootstrapper.cs
+++ b/Assets/Scripts/Setup/SceneBootstrapper.cs
@@ -35,7 +35,11 @@ public class SceneBootstrapper : MonoBehaviour
             Instantiate(config.sceneControllerPrefab);
         }
         var viewModel = Instantiate(config.gameUIViewModelPrefab);
-        var saveService = Instantiate(config.saveServicePrefab);
+        var saveService = FindObjectOfType<PlayerSaveService>();
+        if (saveService == null)
+        {
+            saveService = Instantiate(config.saveServicePrefab);
+        }
 
         var initiator = sceneInitiator;
         if (initiator != null)


### PR DESCRIPTION
## Summary
- Avoid duplicate `PlayerSaveService` creation by reusing existing instance in `SceneBootstrapper`

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899be0291808324ab5c2639bd3d9403