### PR TITLE
Auto-assign player services in end triggers

### DIFF
--- a/Assets/Scripts/Game/LevelEndTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndTrigger.cs
@@ -1,9 +1,49 @@
+using System.Reflection;
 using UnityEngine;
 
 public class LevelEndTrigger : MonoBehaviour
 {
     [SerializeField] private PlayerTemplate playerTemplate;
     [SerializeField] private PlayerSaveService saveService;
+
+    private void Awake()
+    {
+        if (playerTemplate == null && RunProgressManager.Instance != null)
+        {
+            FieldInfo field = typeof(RunProgressManager).GetField("playerTemplate", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field != null)
+            {
+                playerTemplate = field.GetValue(RunProgressManager.Instance) as PlayerTemplate;
+            }
+        }
+
+        if (playerTemplate == null)
+        {
+            PlayerSpawner spawner = FindObjectOfType<PlayerSpawner>();
+            if (spawner != null)
+            {
+                FieldInfo spawnerField = typeof(PlayerSpawner).GetField("playerTemplate", BindingFlags.NonPublic | BindingFlags.Instance);
+                if (spawnerField != null)
+                {
+                    playerTemplate = spawnerField.GetValue(spawner) as PlayerTemplate;
+                }
+            }
+        }
+
+        if (saveService == null)
+        {
+            saveService = FindObjectOfType<PlayerSaveService>();
+        }
+
+        if (playerTemplate == null)
+        {
+            Debug.LogError("LevelEndTrigger: PlayerTemplate reference is missing.");
+        }
+        if (saveService == null)
+        {
+            Debug.LogError("LevelEndTrigger: PlayerSaveService reference is missing.");
+        }
+    }
 
     private void OnTriggerEnter2D(Collider2D other)
     {

--- a/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -9,6 +10,45 @@ public class LevelEndVictoryTrigger : MonoBehaviour
     [SerializeField] private PlayerSaveService saveService;
 
     private bool isVictoryDoor = false;
+
+    private void Awake()
+    {
+        if (playerTemplate == null && RunProgressManager.Instance != null)
+        {
+            FieldInfo field = typeof(RunProgressManager).GetField("playerTemplate", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field != null)
+            {
+                playerTemplate = field.GetValue(RunProgressManager.Instance) as PlayerTemplate;
+            }
+        }
+
+        if (playerTemplate == null)
+        {
+            PlayerSpawner spawner = FindObjectOfType<PlayerSpawner>();
+            if (spawner != null)
+            {
+                FieldInfo spawnerField = typeof(PlayerSpawner).GetField("playerTemplate", BindingFlags.NonPublic | BindingFlags.Instance);
+                if (spawnerField != null)
+                {
+                    playerTemplate = spawnerField.GetValue(spawner) as PlayerTemplate;
+                }
+            }
+        }
+
+        if (saveService == null)
+        {
+            saveService = FindObjectOfType<PlayerSaveService>();
+        }
+
+        if (playerTemplate == null)
+        {
+            Debug.LogError("LevelEndVictoryTrigger: PlayerTemplate reference is missing.");
+        }
+        if (saveService == null)
+        {
+            Debug.LogError("LevelEndVictoryTrigger: PlayerSaveService reference is missing.");
+        }
+    }
 
 
     private void OnTriggerEnter2D(Collider2D collision)


### PR DESCRIPTION
## Summary
- Automatically locate `PlayerTemplate` and `PlayerSaveService` in level end triggers using `Awake`
- Log errors if required dependencies cannot be found

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899c3abcbf88324adbdfa9cd11d739d