### PR TITLE
Add energy and morality to save data

### DIFF
--- a/Assets/Scripts/Player/Data/PlayerSaveService.cs
+++ b/Assets/Scripts/Player/Data/PlayerSaveService.cs
@@ -33,6 +33,7 @@ public class PlayerSaveService : MonoBehaviour, ISaveService
         CurrentSaveData.MaxHealth = controller.Stats.MaxHealth;
         CurrentSaveData.CurrentEnergy = controller.Stats.CurrentEnergy;
         CurrentSaveData.MaxEnergy = controller.Stats.MaxEnergy;
+        CurrentSaveData.Morality = controller.Stats.Morality;
         CurrentSaveData.AttackEnergyCost = controller.Stats.AttackEnergyCost;
         // CurrentSaveData.experience = controller.Stats.Experience;
         // Map other fields as needed
@@ -49,7 +50,8 @@ public class PlayerSaveService : MonoBehaviour, ISaveService
         if (File.Exists(saveFilePath))
         {
             string json = File.ReadAllText(saveFilePath);
-            CurrentSaveData = JsonUtility.FromJson<SaveData>(json);
+            CurrentSaveData = new SaveData();
+            JsonUtility.FromJsonOverwrite(json, CurrentSaveData);
             Debug.Log("Game loaded from " + saveFilePath);
         }
         else

--- a/Assets/Scripts/RobotFactory/PlayerTemplate.cs
+++ b/Assets/Scripts/RobotFactory/PlayerTemplate.cs
@@ -30,12 +30,13 @@ public class PlayerTemplate : RobotTemplate
                 (int)saveData.MaxHealth,
                 (int)saveData.CurrentEnergy,
                 (int)saveData.MaxEnergy,
-                0,
+                (int)saveData.Morality,
                 (int)saveData.AttackEnergyCost);
 
         robotBehaviour.Stats = playerFactory.CreateRobot();
         Debug.Log("PlayerStats initialized with health: " + robotBehaviour.Stats.CurrentHealth
         + " and energy: " + robotBehaviour.Stats.CurrentEnergy
+        + " and morality: " + robotBehaviour.Stats.Morality
         + " and attack energy cost: " + robotBehaviour.Stats.AttackEnergyCost);
 
         return robotBehaviour.Stats;

--- a/Assets/Scripts/Setup/SaveData.cs
+++ b/Assets/Scripts/Setup/SaveData.cs
@@ -8,8 +8,10 @@ public class SaveData
     [field: SerializeField] public float MaxHealth = 100f;
     [field: SerializeField] public float CurrentHealth = 100f;
     [field: SerializeField] public float MaxEnergy { get; set; } = 100f;
+    [field: SerializeField] public float CurrentEnergy { get; set; } = 100f;
     [field: SerializeField] public float EnergyRechargeRate { get; set; } = 5f;
     [field: SerializeField] public float AttackEnergyCost { get; set; } = 5f;
+    [field: SerializeField] public float Morality { get; set; } = 0f;
     [field: SerializeField] public List<string> UnlockedAttacks { get; set; }
     [field: SerializeField] public List<string> AttackOrder { get; set; } // Customizable order of attacks
     [field: SerializeField] public int Gears { get; set; } = 0;// Total gears stored at the camp
@@ -28,6 +30,8 @@ public class SaveData
     {
         Guid g = Guid.NewGuid();
         SaveName = g.ToString();
+        CurrentEnergy = 100f;
+        Morality = 0f;
         UnlockedAttacks = new List<string>(); // Start with no unlocked attacks
         AttackOrder = new List<string>(); // Start with no attack order
         SpecialResources = new Dictionary<string, int>(); // Empty special resources


### PR DESCRIPTION
## Summary
- Persist player's current energy and morality in save data
- Pass saved energy and morality through player initialization
- Load save files with defaults when fields are missing

## Testing
- `dotnet test UnitTests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6899c4e8468883248aac7a50ab0a0889