### PR TITLE
Use GetComponentInParent for level end triggers

### DIFF
--- a/Assets/Scripts/Game/LevelEndTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndTrigger.cs
@@ -49,10 +49,14 @@ public class LevelEndTrigger : MonoBehaviour
     {
         if (other.CompareTag("Player") && RunProgressManager.Instance != null)
         {
-            RobotStateController controller = other.GetComponent<RobotStateController>();
-            GrabSystem grabSystem = other.GetComponent<GrabSystem>();
+            RobotStateController controller = other.GetComponentInParent<RobotStateController>();
+            GrabSystem grabSystem = other.GetComponentInParent<GrabSystem>();
 
-            if (grabSystem != null)
+            if (grabSystem == null)
+            {
+                Debug.LogWarning("LevelEndTrigger: GrabSystem component is missing on Player or its parent.");
+            }
+            else
             {
                 grabSystem.ClearHands();
             }
@@ -64,6 +68,10 @@ public class LevelEndTrigger : MonoBehaviour
                 {
                     saveService.SaveGame(controller);
                 }
+            }
+            else if (controller == null)
+            {
+                Debug.LogWarning("LevelEndTrigger: RobotStateController component is missing on Player or its parent.");
             }
 
             RunProgressManager.Instance.LoadNextLevel();

--- a/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
@@ -63,10 +63,14 @@ public class LevelEndVictoryTrigger : MonoBehaviour
                 || victorySetup.currentSaved >= victorySetup.robotsSavedTarget;
             if (isVictoryDoor && isVictory && collision.CompareTag("Player"))
             {
-                RobotStateController controller = collision.GetComponent<RobotStateController>();
-                GrabSystem grabSystem = collision.GetComponent<GrabSystem>();
+                RobotStateController controller = collision.GetComponentInParent<RobotStateController>();
+                GrabSystem grabSystem = collision.GetComponentInParent<GrabSystem>();
 
-                if (grabSystem != null)
+                if (grabSystem == null)
+                {
+                    Debug.LogWarning("LevelEndVictoryTrigger: GrabSystem component is missing on Player or its parent.");
+                }
+                else
                 {
                     grabSystem.ClearHands();
                 }
@@ -78,6 +82,10 @@ public class LevelEndVictoryTrigger : MonoBehaviour
                     {
                         saveService.SaveGame(controller);
                     }
+                }
+                else if (controller == null)
+                {
+                    Debug.LogWarning("LevelEndVictoryTrigger: RobotStateController component is missing on Player or its parent.");
                 }
 
                 RunProgressManager.Instance.LoadNextLevel();


### PR DESCRIPTION
## Summary
- Ensure level end triggers search for components on player parents
- Warn when expected components are not found for easier debugging

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899d0cf78608324a535e33952c503b4