### PR TITLE
Expose IK solver reinitialization

### DIFF
--- a/Assets/Scripts/Robots/Hinge2DIkSolver.cs
+++ b/Assets/Scripts/Robots/Hinge2DIkSolver.cs
@@ -46,11 +46,29 @@ public class Hinge2DIkSolver : MonoBehaviour {
 
     public delegate void OnSolve ();
     public OnSolve CallBackOnSolve;
-    // Start is called before the first frame update
-    void Start () {
-        init ();
-        // we need to run solve once so the values would at least be somewhat right.
-        Solve ();
+
+    /// <summary>
+    /// Rebuilds cached joints and transforms and runs the solver once.
+    /// </summary>
+    public void Reinitialize() {
+        positions = null;
+        bones = null;
+        bonesT = null;
+        bonesR = null;
+        StartDir = null;
+        bonesLength = null;
+        avAngles = null;
+        angleOffset = null;
+        completeLength = 0f;
+        root = null;
+        rootrb = null;
+
+        init();
+        Solve();
+    }
+
+    private void OnEnable() {
+        Reinitialize();
     }
 
     void init () {

--- a/Assets/Scripts/Robots/JointBreaker.cs
+++ b/Assets/Scripts/Robots/JointBreaker.cs
@@ -124,6 +124,10 @@ public class JointBreaker : MonoBehaviour
         ikSolvers.AddRange(GetComponentsInChildren<Hinge2DIkSolver>());
 
         foreach (var solver in ikSolvers)
-            if (solver != null) solver.enabled = true;
+            if (solver != null)
+            {
+                solver.Reinitialize();
+                solver.enabled = true;
+            }
     }
 }


### PR DESCRIPTION
## Summary
- add Reinitialize method to Hinge2DIkSolver to rebuild cached joints and run an initial solve
- call Reinitialize from OnEnable to reset solvers when components are re-enabled
- ensure JointBreaker.RestoreAll reinitializes each solver before re-enabling

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899d5ec0c088324b12b6ff1734b7839