### PR TITLE
Reset save data on starting or restarting runs

### DIFF
--- a/Assets/Scripts/Menu/MainMenuController.cs
+++ b/Assets/Scripts/Menu/MainMenuController.cs
@@ -53,6 +53,8 @@ public class MainMenuController : MonoBehaviour
     private void OnPlayClicked(ClickEvent evt)
     {
         _audioSource?.Play();
+        var saveService = FindObjectOfType<PlayerSaveService>();
+        saveService?.ResetSaveData();
         runProgressManagerPrefab.LoadFirstLevel();
     }
 

--- a/Assets/Scripts/UI/PauseController.CS
+++ b/Assets/Scripts/UI/PauseController.CS
@@ -31,6 +31,8 @@ public class PauseController : MonoBehaviour
         _pauseAction.Enable();
 
         _pauseUI.OnResumeClicked += TogglePause;
+        _pauseUI.OnRestartClicked += RestartRun;
+        _pauseUI.OnMainMenuClicked += GoToMainMenu;
     }
 
 
@@ -63,6 +65,8 @@ public class PauseController : MonoBehaviour
     {
         Debug.Log("PauseController: RestartRun called");
         // Time.timeScale = 1;
+        var saveService = FindObjectOfType<PlayerSaveService>();
+        saveService?.ResetSaveData();
         RunProgressManager.Instance.RestartRun();
     }
 


### PR DESCRIPTION
## Summary
- reset player save data when starting a new run from the main menu
- reset player save data when restarting a run from the pause menu
- wire up pause menu restart and main menu buttons to controller

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899d5d9fee083248d10dd347cce388a