### PR TITLE
Introduce PlayerRunStats and integrate run data into run flow

### DIFF
--- a/Assets/Scripts/Game/LevelEndTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndTrigger.cs
@@ -1,33 +1,15 @@
-using System.Reflection;
 using UnityEngine;
 
 public class LevelEndTrigger : MonoBehaviour
 {
-    [SerializeField] private PlayerTemplate playerTemplate;
+    [SerializeField] private PlayerRunStats runStats;
     [SerializeField] private PlayerSaveService saveService;
 
     private void Awake()
     {
-        if (playerTemplate == null && RunProgressManager.Instance != null)
+        if (runStats == null && RunProgressManager.Instance != null)
         {
-            FieldInfo field = typeof(RunProgressManager).GetField("playerTemplate", BindingFlags.NonPublic | BindingFlags.Instance);
-            if (field != null)
-            {
-                playerTemplate = field.GetValue(RunProgressManager.Instance) as PlayerTemplate;
-            }
-        }
-
-        if (playerTemplate == null)
-        {
-            PlayerSpawner spawner = FindFirstObjectByType<PlayerSpawner>();
-            if (spawner != null)
-            {
-                FieldInfo spawnerField = typeof(PlayerSpawner).GetField("playerTemplate", BindingFlags.NonPublic | BindingFlags.Instance);
-                if (spawnerField != null)
-                {
-                    playerTemplate = spawnerField.GetValue(spawner) as PlayerTemplate;
-                }
-            }
+            runStats = RunProgressManager.Instance.RunStats;
         }
 
         if (saveService == null)
@@ -35,9 +17,9 @@ public class LevelEndTrigger : MonoBehaviour
             saveService = FindFirstObjectByType<PlayerSaveService>();
         }
 
-        if (playerTemplate == null)
+        if (runStats == null)
         {
-            Debug.LogError("LevelEndTrigger: PlayerTemplate reference is missing.");
+            Debug.LogError("LevelEndTrigger: PlayerRunStats reference is missing.");
         }
         if (saveService == null)
         {
@@ -61,9 +43,9 @@ public class LevelEndTrigger : MonoBehaviour
                 grabSystem.ClearHands();
             }
 
-            if (playerTemplate != null && controller != null)
+            if (runStats != null && controller != null)
             {
-                playerTemplate.CaptureStats(controller.Stats);
+                runStats.Capture(controller.Stats);
                 if (saveService != null)
                 {
                     saveService.SaveGame(controller);

--- a/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
@@ -1,38 +1,18 @@
-using System.Reflection;
 using UnityEngine;
-using UnityEngine.SceneManagement;
-
 public class LevelEndVictoryTrigger : MonoBehaviour
 {
     [SerializeField] private DoorController doorNext;
     [SerializeField] private VictorySetup victorySetup;
-    [SerializeField] private PlayerTemplate playerTemplate;
+    [SerializeField] private PlayerRunStats runStats;
     [SerializeField] private PlayerSaveService saveService;
 
     private bool isVictoryDoor = false;
 
     private void Awake()
     {
-        if (playerTemplate == null && RunProgressManager.Instance != null)
+        if (runStats == null && RunProgressManager.Instance != null)
         {
-            FieldInfo field = typeof(RunProgressManager).GetField("playerTemplate", BindingFlags.NonPublic | BindingFlags.Instance);
-            if (field != null)
-            {
-                playerTemplate = field.GetValue(RunProgressManager.Instance) as PlayerTemplate;
-            }
-        }
-
-        if (playerTemplate == null)
-        {
-            PlayerSpawner spawner = FindFirstObjectByType<PlayerSpawner>();
-            if (spawner != null)
-            {
-                FieldInfo spawnerField = typeof(PlayerSpawner).GetField("playerTemplate", BindingFlags.NonPublic | BindingFlags.Instance);
-                if (spawnerField != null)
-                {
-                    playerTemplate = spawnerField.GetValue(spawner) as PlayerTemplate;
-                }
-            }
+            runStats = RunProgressManager.Instance.RunStats;
         }
 
         if (saveService == null)
@@ -40,9 +20,9 @@ public class LevelEndVictoryTrigger : MonoBehaviour
             saveService = FindFirstObjectByType<PlayerSaveService>();
         }
 
-        if (playerTemplate == null)
+        if (runStats == null)
         {
-            Debug.LogError("LevelEndVictoryTrigger: PlayerTemplate reference is missing.");
+            Debug.LogError("LevelEndVictoryTrigger: PlayerRunStats reference is missing.");
         }
         if (saveService == null)
         {
@@ -75,9 +55,9 @@ public class LevelEndVictoryTrigger : MonoBehaviour
                     grabSystem.ClearHands();
                 }
 
-                if (playerTemplate != null && controller != null)
+                if (runStats != null && controller != null)
                 {
-                    playerTemplate.CaptureStats(controller.Stats);
+                    runStats.Capture(controller.Stats);
                     if (saveService != null)
                     {
                         saveService.SaveGame(controller);

--- a/Assets/Scripts/Game/RunProgressManager.cs
+++ b/Assets/Scripts/Game/RunProgressManager.cs
@@ -11,6 +11,7 @@ public class RunProgressManager : MonoBehaviour
     [SerializeField] private string runSandboxSceneName = "SetupSandbox";
     [SerializeField] private SceneController sceneControllerPrefab;
     [SerializeField] private PlayerTemplate playerTemplate;
+    [SerializeField] private PlayerRunStats runStats;
 
     // Maximum allowed values for dynamically generated configurations
     private const int MaxGridSize = 10;      // Maximum grid width/height
@@ -22,6 +23,7 @@ public class RunProgressManager : MonoBehaviour
     private int currentLevelIndex = 1;
 
     public int CurrentLevelIndex => currentLevelIndex;
+    public PlayerRunStats RunStats => runStats;
 
     public RunMapConfigSO CurrentConfig
     {
@@ -59,12 +61,14 @@ public class RunProgressManager : MonoBehaviour
     {
         currentLevelIndex = 0;
         playerTemplate.ResetStats();
+        runStats.Reset();
         SceneController.instance.LoadScene(runSandboxSceneName);
     }
     public void LoadStressTestLevel()
     {
         currentLevelIndex = 0;
         playerTemplate.ResetStats();
+        runStats.Reset();
         SceneController.instance.LoadScene(runNormalSceneName);
     }
     //load first level
@@ -72,6 +76,7 @@ public class RunProgressManager : MonoBehaviour
     {
         currentLevelIndex = 1;
         playerTemplate.ResetStats();
+        runStats.Reset();
         SceneController.instance.LoadScene(runNormalSceneName);
     }
 
@@ -86,6 +91,7 @@ public class RunProgressManager : MonoBehaviour
     {
         currentLevelIndex = 1;
         playerTemplate.ResetStats();
+        runStats.Reset();
         SceneController.instance.LoadScene(runNormalSceneName);
     }
 

--- a/Assets/Scripts/Player/Core/PlayerSpawner.cs
+++ b/Assets/Scripts/Player/Core/PlayerSpawner.cs
@@ -5,6 +5,7 @@ public class PlayerSpawner : MonoBehaviour, IPlayerSpawner
     [Header("Spawn Settings")]
     [SerializeField] private Vector3 _playerStartPosition;
     [SerializeField] private PlayerTemplate playerTemplate;
+    [SerializeField] private PlayerRunStats runStats;
 
     [Header("Runtime References")]
     public GameObject playerInstance { get; private set; }
@@ -38,10 +39,14 @@ public class PlayerSpawner : MonoBehaviour, IPlayerSpawner
         // Setup behaviour and save-data info
         playerRobotBehaviour = playerTemplate.InitializePlayerStateController(playerInstance);
         playerRobotInfo = playerTemplate.InitializePlayerStats(saveService.CurrentSaveData);
-        // Apply stats before gameplay so HUD and AI use updated values
-        if (playerTemplate.HasCapturedStats)
+        if (runStats == null && RunProgressManager.Instance != null)
         {
-            playerTemplate.ApplyStats(playerRobotInfo);
+            runStats = RunProgressManager.Instance.RunStats;
+        }
+        // Apply stats before gameplay so HUD and AI use updated values
+        if (runStats != null && runStats.HasValues)
+        {
+            runStats.Apply(playerRobotInfo);
         }
 
         // Locate "WholeBody" container

--- a/Assets/Scripts/Player/Data/PlayerRunStats.cs
+++ b/Assets/Scripts/Player/Data/PlayerRunStats.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "PlayerRunStats", menuName = "Player/RunStats")]
+public class PlayerRunStats : ScriptableObject
+{
+    public float currentHealth;
+    public float morality;
+    private bool hasValues;
+
+    public bool HasValues => hasValues;
+
+    /// <summary>
+    /// Captures temporary stats from the source robot.
+    /// </summary>
+    /// <param name="source">Robot providing current values.</param>
+    public void Capture(RobotStats source)
+    {
+        if (source == null)
+        {
+            return;
+        }
+
+        currentHealth = Mathf.Clamp(source.CurrentHealth, 0f, source.MaxHealth);
+        morality = source.Morality;
+        hasValues = true;
+    }
+
+    /// <summary>
+    /// Applies captured stats to the target robot.
+    /// </summary>
+    /// <param name="target">Robot receiving stored values.</param>
+    public void Apply(RobotStats target)
+    {
+        if (target == null || !hasValues)
+        {
+            return;
+        }
+
+        float healthTarget = Mathf.Clamp(currentHealth, 0f, target.MaxHealth);
+        target.UpdateHealth(healthTarget - target.CurrentHealth);
+        target.UpdateMorality(morality - target.Morality);
+    }
+
+    /// <summary>
+    /// Clears the stored run statistics.
+    /// </summary>
+    public void Reset()
+    {
+        currentHealth = 0f;
+        morality = 0f;
+        hasValues = false;
+    }
+}

--- a/Assets/Scripts/Player/Data/PlayerSaveService.cs
+++ b/Assets/Scripts/Player/Data/PlayerSaveService.cs
@@ -29,11 +29,8 @@ public class PlayerSaveService : MonoBehaviour, ISaveService
             CurrentSaveData = new SaveData();
         }
 
-        CurrentSaveData.CurrentHealth = controller.Stats.CurrentHealth;
         CurrentSaveData.MaxHealth = controller.Stats.MaxHealth;
-        CurrentSaveData.CurrentEnergy = controller.Stats.CurrentEnergy;
         CurrentSaveData.MaxEnergy = controller.Stats.MaxEnergy;
-        CurrentSaveData.Morality = controller.Stats.Morality;
         CurrentSaveData.AttackEnergyCost = controller.Stats.AttackEnergyCost;
         // CurrentSaveData.experience = controller.Stats.Experience;
         // Map other fields as needed


### PR DESCRIPTION
## Summary
- add `PlayerRunStats` ScriptableObject to capture and apply temporary health and morality
- use `PlayerRunStats` at level end and spawn start to persist run health/morality between stages
- reset and ignore run stats in `RunProgressManager` and `PlayerSaveService` to keep only long‑term data

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899db494c788324a936b5ec941ef19a