### PR TITLE
feat: add battery pickup system

### DIFF
--- a/Assembly-CSharp-Editor.csproj
+++ b/Assembly-CSharp-Editor.csproj
@@ -100,6 +100,8 @@
     <Compile Include="Assets\Editor\UnitTests\CellTests.cs" />
     <Compile Include="Assets\Editor\UnitTests\PositionTriggerZoneTests.cs" />
     <Compile Include="Assets\Editor\UnitTests\SecurityBadgePickupTests.cs" />
+    <Compile Include="Assets\Editor\UnitTests\BatteryPickupTests.cs" />
+    <Compile Include="Assets\Editor\UnitTests\BatteryTheftTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="UnityEngine">

--- a/Assets/Editor/UnitTests/BatteryPickupTests.cs
+++ b/Assets/Editor/UnitTests/BatteryPickupTests.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+public class BatteryPickupTests
+{
+    private class DummyPlayerMovementController : PlayerMovementController
+    {
+        void Awake() { }
+        void OnEnable() { }
+        void Update() { }
+    }
+
+    [Test]
+    public void Battery_AddsHealthAndAttaches()
+    {
+        var playerGO = new GameObject("player");
+        playerGO.AddComponent<EnergyBot>();
+        playerGO.AddComponent<HealthBot>();
+        var playerState = playerGO.AddComponent<RobotStateController>();
+        playerState.Stats = new RobotStats();
+        playerState.Stats.MaxHealth = 100f;
+        playerState.Stats.CurrentHealth = 50f;
+
+        var playerRb = playerGO.AddComponent<Rigidbody2D>();
+        var player = playerGO.AddComponent<DummyPlayerMovementController>();
+        typeof(PlayerMovementController)
+            .GetField("bodyReference", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(player, playerRb);
+
+        var hand = new GameObject("hand").transform;
+        hand.SetParent(playerGO.transform);
+
+        var batteryGO = new GameObject("battery");
+        batteryGO.AddComponent<Rigidbody2D>();
+        batteryGO.AddComponent<TargetJoint2D>();
+        var battery = batteryGO.AddComponent<BatteryPickup>();
+
+        battery.OnGrab(hand);
+
+        Assert.AreEqual(60f, playerState.Stats.CurrentHealth);
+        Assert.IsFalse(battery.CanBeGrabbed());
+        BatteryPickup.DropPlayerBattery();
+        Assert.IsNull(BatteryPickup.PlayerHeldBattery);
+    }
+}

--- a/Assets/Editor/UnitTests/BatteryTheftTests.cs
+++ b/Assets/Editor/UnitTests/BatteryTheftTests.cs
@@ -1,0 +1,54 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+public class BatteryTheftTests
+{
+    private class DummyPlayerMovementController : PlayerMovementController
+    {
+        void Awake() { }
+        void OnEnable() { }
+        void Update() { }
+    }
+
+    [Test]
+    public void StealingBattery_ReducesEnemyHealth()
+    {
+        var enemyGO = new GameObject("enemy");
+        enemyGO.AddComponent<EnergyBot>();
+        enemyGO.AddComponent<HealthBot>();
+        var enemyState = enemyGO.AddComponent<RobotStateController>();
+        enemyState.Stats = new RobotStats();
+        enemyState.Stats.MaxHealth = 100f;
+        enemyState.Stats.CurrentHealth = 50f;
+        enemyGO.AddComponent<EnemyStateMachine>();
+        var enemy = enemyGO.AddComponent<EnemyController>();
+        enemy.EnemyStatus = EnemyStatus.Idle;
+
+        var batteryGO = new GameObject("battery");
+        batteryGO.transform.SetParent(enemyGO.transform);
+        batteryGO.AddComponent<Rigidbody2D>();
+        batteryGO.AddComponent<TargetJoint2D>();
+        var battery = batteryGO.AddComponent<BatteryPickup>();
+
+        var playerGO = new GameObject("player");
+        playerGO.AddComponent<EnergyBot>();
+        playerGO.AddComponent<HealthBot>();
+        var playerState = playerGO.AddComponent<RobotStateController>();
+        playerState.Stats = new RobotStats();
+        playerState.Stats.MaxHealth = 100f;
+        playerState.Stats.CurrentHealth = 40f;
+        var playerRb = playerGO.AddComponent<Rigidbody2D>();
+        var player = playerGO.AddComponent<DummyPlayerMovementController>();
+        typeof(PlayerMovementController)
+            .GetField("bodyReference", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(player, playerRb);
+        var hand = new GameObject("hand").transform;
+        hand.SetParent(playerGO.transform);
+
+        battery.OnGrab(hand);
+
+        Assert.AreEqual(50f - 10f, enemyState.Stats.CurrentHealth);
+        Assert.AreEqual(40f + 10f, playerState.Stats.CurrentHealth);
+    }
+}

--- a/Assets/Editor/UnitTests/FactoryManagerTests.cs
+++ b/Assets/Editor/UnitTests/FactoryManagerTests.cs
@@ -101,7 +101,7 @@ public class FactoryManagerTests
     }
     private class DummyEnemiesSpawner : IEnemiesSpawner
     {
-        public void Initialize(MapManager mapManager, IWaypointService waypointService, GameUIViewModel viewModel, IRobotRespawnService respawnService, MachineSecurityManager securityManager, SecurityBadgeSpawner securityBadgeSpawner) { }
+        public void Initialize(MapManager mapManager, IWaypointService waypointService, GameUIViewModel viewModel, IRobotRespawnService respawnService, MachineSecurityManager securityManager, SecurityBadgeSpawner securityBadgeSpawner, BatterySpawner batterySpawner) { }
         public void SetDropContainer(Transform container) { }
         public void CreateWorkers(int workersToSpawn) { }
         public void CreateEnemies(int enemiesToSpawn) { }

--- a/Assets/Editor/UnitTests/SceneInitiatorTests.cs
+++ b/Assets/Editor/UnitTests/SceneInitiatorTests.cs
@@ -15,6 +15,6 @@ public class SceneInitiatorTests
     [Test]
     public void Start_InitializesScene()
     {
-        Assert.DoesNotThrow(() => _initiator.Construct(null, null, null, null, null, null, null, null,null, null));
+        Assert.DoesNotThrow(() => _initiator.Construct(null, null, null, null, null, null, null, null, null, null, null));
     }
 }

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -37,6 +37,7 @@ public class EnemyController : PhysicsBaseAgentController, IPooledObject
     public EnemyStatus EnemyStatus { get; set; } = EnemyStatus.Idle;
 
     private SecurityBadgePickup initialBadge;
+    private BatteryPickup initialBattery;
 
     private Transform dropContainer;
 
@@ -62,7 +63,8 @@ public class EnemyController : PhysicsBaseAgentController, IPooledObject
         IWaypointNotifier waypointNotifier,
         IRobotRespawnService respawnService,
         Transform dropContainer,
-        SecurityBadgeSpawner securityBadgeSpawner)
+        SecurityBadgeSpawner securityBadgeSpawner,
+        BatterySpawner batterySpawner = null)
     {
         this.waypointQueries = waypointQueries;
         this.waypointNotifier = waypointNotifier;
@@ -75,6 +77,13 @@ public class EnemyController : PhysicsBaseAgentController, IPooledObject
         if (securityBadgeSpawner && initialBadge == null)
         {
             initialBadge = securityBadgeSpawner.SpawnBadge(bodyReference);
+        }
+
+        if (batterySpawner && initialBattery == null)
+        {
+            initialBattery = batterySpawner.SpawnBattery(bodyReference);
+            if (robotBehaviour != null)
+                robotBehaviour.Stats.UpdateHealth(10f);
         }
     }
 
@@ -172,20 +181,32 @@ public class EnemyController : PhysicsBaseAgentController, IPooledObject
 
     private void DetachHeldBadges()
     {
-        if (initialBadge == null) return;
-
-        initialBadge.OnRelease(Vector2.zero);
-
-        if (dropContainer != null)
+        if (initialBadge != null)
         {
-            initialBadge.transform.SetParent(dropContainer, true);
+            initialBadge.OnRelease(Vector2.zero);
+            if (dropContainer != null)
+                initialBadge.transform.SetParent(dropContainer, true);
+            initialBadge = null;
         }
-        initialBadge = null;
+
+        if (initialBattery != null)
+        {
+            initialBattery.OnRelease(Vector2.zero);
+            if (dropContainer != null)
+                initialBattery.transform.SetParent(dropContainer, true);
+            initialBattery = null;
+        }
     }
 
     public void OnBadgeStolen(GameObject player)
     {
         Debug.Log($"{name} badge stolen by {player.name}");
+    }
+
+    public void OnBatteryStolen(GameObject player)
+    {
+        Debug.Log($"{name} battery stolen by {player.name}");
+        robotBehaviour.Health.TakeDamage(10);
     }
 
     private void UpdateBalance(bool enabledBalance)

--- a/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
@@ -73,6 +73,7 @@ public class LevelEndVictoryTrigger : MonoBehaviour
                 else
                 {
                     grabSystem.ClearHands();
+                    BatteryPickup.DropPlayerBattery();
                 }
 
                 if (playerTemplate != null && controller != null)

--- a/Assets/Scripts/Game/SceneInitiator.cs
+++ b/Assets/Scripts/Game/SceneInitiator.cs
@@ -15,6 +15,7 @@ public class SceneInitiator : GameInitiator
     private ISaveService saveService;
     private SceneController sceneController;
     private SecurityBadgeSpawner securityBadgeSpawner;
+    private BatterySpawner batterySpawner;
 
     public void Construct(
         IFactoryManager factoryManager,
@@ -26,7 +27,8 @@ public class SceneInitiator : GameInitiator
         IRobotRespawnService respawnService,
         VictorySetup victorySetup,
         ISaveService saveService,
-        SecurityBadgeSpawner securityBadgeSpawner)
+        SecurityBadgeSpawner securityBadgeSpawner,
+        BatterySpawner batterySpawner)
     {
         this.factoryManager = factoryManager;
         this.gameUIViewModel = gameUIViewModel;
@@ -38,6 +40,7 @@ public class SceneInitiator : GameInitiator
         this.victorySetup = victorySetup;
         this.saveService = saveService;
         this.securityBadgeSpawner = securityBadgeSpawner;
+        this.batterySpawner = batterySpawner;
 
         if (RunProgressManager.Instance != null)
         {
@@ -101,7 +104,8 @@ public class SceneInitiator : GameInitiator
              gameUIViewModel,
              respawnService,
              factoryManager.SecurityManager,
-             securityBadgeSpawner);
+             securityBadgeSpawner,
+             batterySpawner);
         if (mapConfig != null)
         {
             enemiesSpawner?.CreateWorkers(mapConfig.workersCount);

--- a/Assets/Scripts/Interfaces/IEnemiesSpawner.cs
+++ b/Assets/Scripts/Interfaces/IEnemiesSpawner.cs
@@ -8,7 +8,8 @@ public interface IEnemiesSpawner
         GameUIViewModel viewModel,
         IRobotRespawnService respawnService,
         MachineSecurityManager securityManager,
-        SecurityBadgeSpawner securityBadgeSpawner);
+        SecurityBadgeSpawner securityBadgeSpawner,
+        BatterySpawner batterySpawner);
     void SetDropContainer(Transform container);
     void CreateWorkers(int workersToSpawn);
     void CreateEnemies(int enemiesToSpawn);

--- a/Assets/Scripts/Managers/EnemiesSpawner.cs
+++ b/Assets/Scripts/Managers/EnemiesSpawner.cs
@@ -23,6 +23,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
 
     public Transform DropContainer => dropContainer;
     private SecurityBadgeSpawner securityBadgeSpawner;
+    private BatterySpawner batterySpawner;
 
     public void SetDropContainer(Transform container)
     {
@@ -35,7 +36,8 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         GameUIViewModel viewModel,
         IRobotRespawnService respawnService,
         MachineSecurityManager securityManager,
-        SecurityBadgeSpawner securityBadgeSpawner)
+        SecurityBadgeSpawner securityBadgeSpawner,
+        BatterySpawner batterySpawner)
     {
         this.waypointService = waypointService;
         this.mapManager = mapManager;
@@ -43,6 +45,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         this.respawnService = respawnService;
         this.securityManager = securityManager;
         this.securityBadgeSpawner = securityBadgeSpawner;
+        this.batterySpawner = batterySpawner;
 
         if (respawnService is RobotRespawnService service)
             service.Initialize(this);
@@ -155,7 +158,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
 
         // 3) NOW it’s in the world at the correct spot — initialize its AI
         var ec = follower.GetComponent<EnemyController>();
-        ec.Initialize(waypointService, waypointService, respawnService, dropContainer, securityBadgeSpawner);
+        ec.Initialize(waypointService, waypointService, respawnService, dropContainer, securityBadgeSpawner, batterySpawner);
         ec.SetFollowerState(factoryAlarmStatus);
 
         ec.memory.SetLastVisitedPoint(spawnPos);
@@ -177,7 +180,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         guard.SetActive(true);
 
         var ec = guard.GetComponent<EnemyController>();
-        ec.Initialize(waypointService, waypointService, respawnService, dropContainer, securityBadgeSpawner);
+        ec.Initialize(waypointService, waypointService, respawnService, dropContainer, securityBadgeSpawner, batterySpawner);
 
         ec.SetSecurityGuardState();
         ec.memory.SetLastVisitedPoint(spawnPos);
@@ -237,7 +240,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
 
             // 3) NOW it’s in the world at the correct spot — initialize its AI
             var ec = enemy.GetComponent<EnemyController>();
-            ec.Initialize(waypointService, waypointService, respawnService, dropContainer, securityBadgeSpawner);
+            ec.Initialize(waypointService, waypointService, respawnService, dropContainer, securityBadgeSpawner, batterySpawner);
             ec.memory.SetLastVisitedPoint(spawnPos);
             var guardAI = enemy.GetComponent<ReactiveMachineAI>();
             guardAI?.Initialize(waypointService, securityManager);
@@ -258,7 +261,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
 
             // 3) NOW it’s in the world at the correct spot — initialize its AI
             var ec = boosInstance.GetComponent<EnemyController>();
-            ec.Initialize(waypointService, waypointService, respawnService, dropContainer, securityBadgeSpawner);
+            ec.Initialize(waypointService, waypointService, respawnService, dropContainer, securityBadgeSpawner, batterySpawner);
             ec.SetBossState();
             ec.memory.SetLastVisitedPoint(spawnPos);
 

--- a/Assets/Scripts/Player/Controllers/PlayerMovementController.cs
+++ b/Assets/Scripts/Player/Controllers/PlayerMovementController.cs
@@ -159,8 +159,9 @@ public class PlayerMovementController : MonoBehaviour, ILookDirectionProvider
 
     public void Die()
     {
-        // Drop any badge the player is carrying
+        // Drop any badge or battery the player is carrying
         SecurityBadgePickup.DropPlayerBadge();
+        BatteryPickup.DropPlayerBattery();
 
         var jointBreaker = GetComponent<JointBreaker>();
         jointBreaker?.BreakAll();

--- a/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
@@ -1,0 +1,154 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody2D), typeof(TargetJoint2D))]
+public class BatteryPickup : MonoBehaviour, IGrabbable
+{
+    [Header("Health settings")]
+    [SerializeField] private float healthGain = 10f;
+
+    [Header("Target Joint Settings")]
+    [Tooltip("How springy the joint movement is.")]
+    [SerializeField] private float frequency = 5f;
+    [Tooltip("How much the joint resists oscillation.")]
+    [SerializeField] private float dampingRatio = 0.8f;
+    [Tooltip("Maximum force the joint can apply.")]
+    [SerializeField] private float maxForce = 1000f;
+
+    private Rigidbody2D rb;
+    private TargetJoint2D joint;
+    private Transform followTarget;
+    private bool attached = false;
+    private bool wasStolen = false;
+
+    public static BatteryPickup PlayerHeldBattery { get; private set; }
+    private bool heldByPlayer = false;
+
+    private void Awake()
+    {
+        rb = GetComponent<Rigidbody2D>();
+        joint = GetComponent<TargetJoint2D>();
+
+        joint.enabled = false;
+        joint.autoConfigureTarget = false;
+        joint.target = rb.position;
+        joint.frequency = frequency;
+        joint.dampingRatio = dampingRatio;
+        joint.maxForce = maxForce;
+    }
+
+    private void FixedUpdate()
+    {
+        if (joint.enabled && followTarget != null)
+            joint.target = followTarget.position;
+    }
+
+    public void SetFollowTarget(Transform target)
+    {
+        followTarget = target;
+        if (joint == null)
+            joint = GetComponent<TargetJoint2D>();
+
+        if (joint != null)
+        {
+            if (followTarget != null)
+                joint.target = followTarget.position;
+            joint.enabled = true;
+        }
+        else
+        {
+            Debug.LogWarning($"{nameof(BatteryPickup)} on {name} is missing a {nameof(TargetJoint2D)} component.");
+        }
+    }
+
+    public bool CanBeGrabbed()
+    {
+        if (PlayerHeldBattery != null && PlayerHeldBattery != this)
+            return false;
+        return !attached;
+    }
+
+    public void OnGrab(Transform grabParent)
+    {
+        if (PlayerHeldBattery != null && PlayerHeldBattery != this)
+            return;
+
+        var player = grabParent.GetComponentInParent<PlayerMovementController>();
+
+        if (!wasStolen && transform.parent != null)
+        {
+            var enemy = transform.parent.GetComponentInParent<EnemyController>();
+            if (enemy != null)
+            {
+                var stateController = enemy.GetComponent<RobotStateController>();
+                if (stateController != null && stateController.CurrentState != RobotState.Dead && player != null)
+                {
+                    enemy.OnBatteryStolen(player.gameObject);
+                    wasStolen = true;
+                }
+            }
+        }
+
+        attached = true;
+        rb.simulated = true;
+
+        var holderState = grabParent.GetComponentInParent<RobotStateController>();
+        if (holderState != null)
+            holderState.Stats.UpdateHealth(healthGain);
+
+        if (player != null)
+        {
+            var hip = player.BodyReference;
+            if (hip != null)
+            {
+                PlayerHeldBattery = this;
+                heldByPlayer = true;
+                SetFollowTarget(hip.transform);
+
+                foreach (var battery in FindObjectsByType<BatteryPickup>(FindObjectsSortMode.None))
+                {
+                    if (battery != this)
+                        Destroy(battery.gameObject);
+                }
+            }
+        }
+        else
+        {
+            SetFollowTarget(grabParent);
+        }
+    }
+
+    public void OnAttract(Vector2 attractPoint)
+    {
+        if (attached && joint.enabled && followTarget == null)
+            joint.target = attractPoint;
+    }
+
+    public void OnRelease(Vector2 throwForce)
+    {
+        attached = false;
+        joint.enabled = false;
+        followTarget = null;
+
+        if (heldByPlayer)
+        {
+            heldByPlayer = false;
+            if (PlayerHeldBattery == this)
+                PlayerHeldBattery = null;
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (PlayerHeldBattery == this)
+            PlayerHeldBattery = null;
+    }
+
+    public static void DropPlayerBattery()
+    {
+        if (PlayerHeldBattery != null)
+        {
+            Destroy(PlayerHeldBattery.gameObject);
+            PlayerHeldBattery = null;
+        }
+    }
+}

--- a/Assets/Scripts/Player/GrabSystem/GrabSystem.cs
+++ b/Assets/Scripts/Player/GrabSystem/GrabSystem.cs
@@ -83,8 +83,8 @@ public class GrabSystem : MonoBehaviour
         {
             obj.OnGrab(hand.transform);
 
-            // Badges attach to the player's body and should not remain in hand
-            if (obj is SecurityBadgePickup)
+            // Badges or batteries attach to the player's body and should not remain in hand
+            if (obj is SecurityBadgePickup || obj is BatteryPickup)
             {
                 held = null;
             }

--- a/Assets/Scripts/ScriptObjects/SceneTutorialBoostrap.asset
+++ b/Assets/Scripts/ScriptObjects/SceneTutorialBoostrap.asset
@@ -19,6 +19,7 @@ MonoBehaviour:
   waypointServicePrefab: {fileID: 604041955278505729, guid: cd189dbc195162d4f82e578e1bf48275, type: 3}
   respawnServicePrefab: {fileID: 2201941774247748942, guid: 2738a4e7ee710ef4ab66ab6cca2af1a3, type: 3}
   badgeSpawnerPrefab: {fileID: 2599893765140896267, guid: 824e0a32fecc7e7428f19bb692f62171, type: 3}
+  batterySpawnerPrefab: {fileID: 0}
   sceneControllerPrefab: {fileID: 3662908670334199631, guid: 3bf2939990ae2ab4f91281497ab365f7, type: 3}
   gameUIViewModelPrefab: {fileID: 7317822581930453079, guid: 5a8f0b8511669f44fa106314ede53f67, type: 3}
   victorySetupPrefab: {fileID: 11400000, guid: 71f325ff527d30649a5443ec4acf43a7, type: 2}

--- a/Assets/Scripts/Services/BatterySpawner.cs
+++ b/Assets/Scripts/Services/BatterySpawner.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+public class BatterySpawner : MonoBehaviour
+{
+    [SerializeField] private BatteryPickup batteryPrefab;
+
+    public BatteryPickup SpawnBattery(Transform parent)
+    {
+        if (batteryPrefab == null)
+        {
+            Debug.LogWarning("BatterySpawner: batteryPrefab is null!");
+            return null;
+        }
+
+        var battery = Instantiate(
+            batteryPrefab,
+            parent.position,
+            parent.rotation,
+            parent
+        );
+
+        battery.SetFollowTarget(parent);
+
+        return battery;
+    }
+}

--- a/Assets/Scripts/Setup/SceneBootstrapConfigSO.cs
+++ b/Assets/Scripts/Setup/SceneBootstrapConfigSO.cs
@@ -10,6 +10,7 @@ public class SceneBootstrapConfigSO : ScriptableObject
     public WaypointService waypointServicePrefab;
     public RobotRespawnService respawnServicePrefab;
     public SecurityBadgeSpawner badgeSpawnerPrefab;
+    public BatterySpawner batterySpawnerPrefab;
     public SceneController sceneControllerPrefab;
     public GameUIViewModel gameUIViewModelPrefab;
     public VictorySetup victorySetupPrefab;

--- a/Assets/Scripts/Setup/SceneBootstrapper.cs
+++ b/Assets/Scripts/Setup/SceneBootstrapper.cs
@@ -30,6 +30,7 @@ public class SceneBootstrapper : MonoBehaviour
         var waypointService = Instantiate(config.waypointServicePrefab);
         var respawnService = Instantiate(config.respawnServicePrefab);
         var badgeSpawner = Instantiate(config.badgeSpawnerPrefab);
+        var batterySpawner = Instantiate(config.batterySpawnerPrefab);
         if (SceneController.instance == null)
         {
             Instantiate(config.sceneControllerPrefab);
@@ -54,7 +55,8 @@ public class SceneBootstrapper : MonoBehaviour
                 respawnService,
                 config.victorySetupPrefab,
                 saveService,
-                badgeSpawner
+                badgeSpawner,
+                batterySpawner
             );
         }
 

--- a/Assets/Scripts/UI/RunSetupManager.cs
+++ b/Assets/Scripts/UI/RunSetupManager.cs
@@ -331,7 +331,7 @@ public class RunSetupManager : MonoBehaviour
         waypointServiceInstance = Instantiate(waypointServicePrefab);
         enemiesSpawnerInstance = Instantiate(enemiesSpawnerPrefab);
         enemiesSpawnerInstance.SetDropContainer(factoryManagerInstance.transform);
-        enemiesSpawnerInstance.Initialize(mapManagerInstance, waypointServiceInstance, null, null, factoryManagerInstance.SecurityManager, null);
+        enemiesSpawnerInstance.Initialize(mapManagerInstance, waypointServiceInstance, null, null, factoryManagerInstance.SecurityManager, null, null);
 
         miniMapPreviewInstance = Instantiate(miniMapPreviewPrefab);
 

--- a/Game.csproj
+++ b/Game.csproj
@@ -225,6 +225,7 @@
     <Compile Include="Assets\Scripts\Interfaces\IRobotMemory.cs" />
     <Compile Include="Assets\Scripts\Robots\HealthBot.cs" />
     <Compile Include="Assets\Scripts\Player\GrabSystem\SecurityBadgePickup.cs" />
+    <Compile Include="Assets\Scripts\Player\GrabSystem\BatteryPickup.cs" />
     <Compile Include="Assets\Scripts\RobotFactory\AllyRobotFactory.cs" />
     <Compile Include="Assets\Scripts\Setup\GameInitiator.cs" />
     <Compile Include="Assets\Scripts\Interfaces\IWaypointService.cs" />
@@ -270,6 +271,7 @@
     <Compile Include="Assets\Scripts\Robots\FootStepper.cs" />
     <Compile Include="Assets\Scripts\Navigation\RoomLiftPerFloorProcessor.cs" />
     <Compile Include="Assets\Scripts\Services\SecurityBadgeSpawner.cs" />
+    <Compile Include="Assets\Scripts\Services\BatterySpawner.cs" />
     <Compile Include="Assets\Scripts\Robots\Hinge2DIkSolver.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\Controllers\FollowPlayerTriggerHandler.cs" />
     <Compile Include="Assets\Scripts\EnemyAI\States\Worker_GoingToLeastWorkedStation.cs" />


### PR DESCRIPTION
## Summary
- add health-boosting BatteryPickup and spawning service
- let enemies lose 10 health when their battery is stolen
- drop carried battery on player death or victory

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899db85fe208324b8cb6a2f38892f98