### PR TITLE
Add inventory component for grabable pickups

### DIFF
--- a/Assets/Editor/UnitTests/BatteryPickupTests.cs
+++ b/Assets/Editor/UnitTests/BatteryPickupTests.cs
@@ -24,6 +24,7 @@ public class BatteryPickupTests
 
         var playerRb = playerGO.AddComponent<Rigidbody2D>();
         var player = playerGO.AddComponent<DummyPlayerMovementController>();
+        var inventory = playerGO.AddComponent<Inventory>();
         typeof(PlayerMovementController)
             .GetField("bodyReference", BindingFlags.NonPublic | BindingFlags.Instance)
             .SetValue(player, playerRb);
@@ -40,7 +41,8 @@ public class BatteryPickupTests
 
         Assert.AreEqual(60f, playerState.Stats.CurrentHealth);
         Assert.IsFalse(battery.CanBeGrabbed());
-        BatteryPickup.DropPlayerBattery();
-        Assert.IsNull(BatteryPickup.PlayerHeldBattery);
+        Assert.AreEqual(battery, inventory.GetItem(PickupType.Battery));
+        inventory.DropItem(PickupType.Battery);
+        Assert.IsFalse(inventory.HasItem(PickupType.Battery));
     }
 }

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 using System;
 using System.Collections;
 
-[RequireComponent(typeof(EnemyStateMachine), typeof(RobotMemory))]
+[RequireComponent(typeof(EnemyStateMachine), typeof(RobotMemory), typeof(Inventory))]
 /// <summary>
 /// Controls enemy behaviour and state transitions. Initializes path following
 /// and badge spawning services and provides APIs to change state or assign
@@ -30,6 +30,7 @@ public class EnemyController : PhysicsBaseAgentController, IPooledObject
     public Transform BodyReference => bodyReference;
 
     [SerializeField] private EnemyPunchAttack punchAttack;
+    [SerializeField] private Inventory inventory;
 
     private FactoryAlarmStatus alarmStatus;
 
@@ -56,6 +57,9 @@ public class EnemyController : PhysicsBaseAgentController, IPooledObject
             robotBehaviour = GetComponent<RobotStateController>();
 
         robotBehaviour.OnStateChanged += HandleStateChange;
+
+        if (inventory == null)
+            inventory = GetComponent<Inventory>();
     }
 
     public void Initialize(
@@ -77,6 +81,11 @@ public class EnemyController : PhysicsBaseAgentController, IPooledObject
         if (securityBadgeSpawner && initialBadge == null)
         {
             initialBadge = securityBadgeSpawner.SpawnBadge(bodyReference);
+            if (inventory != null && initialBadge != null)
+            {
+                initialBadge.AssignInventory(inventory);
+                inventory.SetItem(PickupType.SecurityBadge, initialBadge);
+            }
         }
 
         if (batterySpawner && initialBattery == null)
@@ -84,6 +93,11 @@ public class EnemyController : PhysicsBaseAgentController, IPooledObject
             initialBattery = batterySpawner.SpawnBattery(bodyReference);
             if (robotBehaviour != null)
                 robotBehaviour.Stats.UpdateHealth(10f);
+            if (inventory != null && initialBattery != null)
+            {
+                initialBattery.AssignInventory(inventory);
+                inventory.SetItem(PickupType.Battery, initialBattery);
+            }
         }
     }
 

--- a/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
@@ -53,7 +53,8 @@ public class LevelEndVictoryTrigger : MonoBehaviour
                 else
                 {
                     grabSystem.ClearHands();
-                    BatteryPickup.DropPlayerBattery();
+                    var inventory = collision.GetComponentInParent<Inventory>();
+                    inventory?.DropAll();
                 }
 
                 if (runStats != null && controller != null)

--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum PickupType
+{
+    SecurityBadge,
+    Battery
+}
+
+/// <summary>
+/// Simple inventory that tracks one pickup per slot.
+/// </summary>
+public class Inventory : MonoBehaviour
+{
+    private readonly Dictionary<PickupType, IGrabbable> items = new Dictionary<PickupType, IGrabbable>();
+
+    /// <summary>
+    /// Checks if the inventory currently holds an item of the given type.
+    /// </summary>
+    public bool HasItem(PickupType type)
+    {
+        return items.ContainsKey(type) && items[type] != null;
+    }
+
+    /// <summary>
+    /// Gets the item stored in the specified slot, if any.
+    /// </summary>
+    public IGrabbable GetItem(PickupType type)
+    {
+        items.TryGetValue(type, out var item);
+        return item;
+    }
+
+    /// <summary>
+    /// Sets the item stored in the specified slot.
+    /// </summary>
+    public void SetItem(PickupType type, IGrabbable item)
+    {
+        items[type] = item;
+    }
+
+    /// <summary>
+    /// Removes the item stored in the specified slot.
+    /// </summary>
+    public void RemoveItem(PickupType type)
+    {
+        if (items.ContainsKey(type))
+            items.Remove(type);
+    }
+
+    /// <summary>
+    /// Drops the item in the specified slot by releasing it and clearing the slot.
+    /// </summary>
+    public void DropItem(PickupType type)
+    {
+        if (items.TryGetValue(type, out var item) && item != null)
+        {
+            item.OnRelease(Vector2.zero);
+        }
+        items.Remove(type);
+    }
+
+    /// <summary>
+    /// Drops all items currently held.
+    /// </summary>
+    public void DropAll()
+    {
+        foreach (var kvp in items)
+        {
+            kvp.Value.OnRelease(Vector2.zero);
+        }
+        items.Clear();
+    }
+}
+

--- a/Assets/Scripts/Inventory/Inventory.cs.meta
+++ b/Assets/Scripts/Inventory/Inventory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c0fc7a5ea4be4010be29e4887b018d45

--- a/Assets/Scripts/Player/Controllers/PlayerMovementController.cs
+++ b/Assets/Scripts/Player/Controllers/PlayerMovementController.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-[RequireComponent(typeof(RobotLocomotionController))]
+[RequireComponent(typeof(RobotLocomotionController), typeof(Inventory))]
 public class PlayerMovementController : MonoBehaviour, ILookDirectionProvider
 {
     [Header("Components")]
@@ -26,6 +26,7 @@ public class PlayerMovementController : MonoBehaviour, ILookDirectionProvider
     private float targetRotation;
 
     [SerializeField] private EnergyBot energyBot;
+    [SerializeField] private Inventory inventory;
 
     private Vector2 lookDirection = Vector2.right;
 
@@ -43,6 +44,9 @@ public class PlayerMovementController : MonoBehaviour, ILookDirectionProvider
             robotBehaviour = GetComponent<RobotStateController>();
 
         robotBehaviour.OnStateChanged += HandleStateChange;
+
+        if (inventory == null)
+            inventory = GetComponent<Inventory>();
 
         input = inputSource as IPlayerInput;
         if (input == null)
@@ -159,9 +163,7 @@ public class PlayerMovementController : MonoBehaviour, ILookDirectionProvider
 
     public void Die()
     {
-        // Drop any badge or battery the player is carrying
-        SecurityBadgePickup.DropPlayerBadge();
-        BatteryPickup.DropPlayerBattery();
+        inventory?.DropAll();
 
         var jointBreaker = GetComponent<JointBreaker>();
         jointBreaker?.BreakAll();

--- a/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
@@ -20,8 +20,7 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
     private bool attached = false;
     private bool wasStolen = false;
 
-    public static BatteryPickup PlayerHeldBattery { get; private set; }
-    private bool heldByPlayer = false;
+    private Inventory ownerInventory;
 
     private void Awake()
     {
@@ -62,16 +61,23 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
 
     public bool CanBeGrabbed()
     {
-        if (PlayerHeldBattery != null && PlayerHeldBattery != this)
-            return false;
+        var player = FindObjectOfType<PlayerMovementController>();
+        if (player != null)
+        {
+            var inventory = player.GetComponent<Inventory>();
+            if (inventory != null)
+            {
+                var held = inventory.GetItem(PickupType.Battery);
+                if (held != null && held != this)
+                    return false;
+            }
+        }
         return !attached;
     }
 
     public void OnGrab(Transform grabParent)
     {
-        if (PlayerHeldBattery != null && PlayerHeldBattery != this)
-            return;
-
+        var inventory = grabParent.GetComponentInParent<Inventory>();
         var player = grabParent.GetComponentInParent<PlayerMovementController>();
 
         if (!wasStolen && transform.parent != null)
@@ -95,21 +101,21 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
         if (holderState != null)
             holderState.Stats.UpdateHealth(healthGain);
 
+        if (inventory != null)
+        {
+            if (ownerInventory != null && ownerInventory != inventory)
+                ownerInventory.RemoveItem(PickupType.Battery);
+            inventory.SetItem(PickupType.Battery, this);
+            ownerInventory = inventory;
+        }
+
         if (player != null)
         {
             var hip = player.BodyReference;
             if (hip != null)
-            {
-                PlayerHeldBattery = this;
-                heldByPlayer = true;
                 SetFollowTarget(hip.transform);
-
-                foreach (var battery in FindObjectsByType<BatteryPickup>(FindObjectsSortMode.None))
-                {
-                    if (battery != this)
-                        Destroy(battery.gameObject);
-                }
-            }
+            else
+                SetFollowTarget(grabParent);
         }
         else
         {
@@ -129,26 +135,18 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
         joint.enabled = false;
         followTarget = null;
 
-        if (heldByPlayer)
+        if (ownerInventory != null)
         {
-            heldByPlayer = false;
-            if (PlayerHeldBattery == this)
-                PlayerHeldBattery = null;
+            ownerInventory.RemoveItem(PickupType.Battery);
+            ownerInventory = null;
         }
     }
 
-    private void OnDestroy()
+    /// <summary>
+    /// Sets the inventory that currently owns this pickup.
+    /// </summary>
+    public void AssignInventory(Inventory inventory)
     {
-        if (PlayerHeldBattery == this)
-            PlayerHeldBattery = null;
-    }
-
-    public static void DropPlayerBattery()
-    {
-        if (PlayerHeldBattery != null)
-        {
-            Destroy(PlayerHeldBattery.gameObject);
-            PlayerHeldBattery = null;
-        }
+        ownerInventory = inventory;
     }
 }

--- a/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
@@ -22,9 +22,7 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
     // Flag to ensure stolen logic only runs once
     bool wasStolen = false;
 
-    // Tracks the badge currently held by the player
-    public static SecurityBadgePickup PlayerHeldBadge { get; private set; }
-    bool heldByPlayer = false;
+    Inventory ownerInventory;
 
     void Awake()
     {
@@ -74,17 +72,23 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
 
     public bool CanBeGrabbed()
     {
-        if (PlayerHeldBadge != null && PlayerHeldBadge != this)
-            return false;
+        var player = FindObjectOfType<PlayerMovementController>();
+        if (player != null)
+        {
+            var inventory = player.GetComponent<Inventory>();
+            if (inventory != null)
+            {
+                var held = inventory.GetItem(PickupType.SecurityBadge);
+                if (held != null && held != this)
+                    return false;
+            }
+        }
         return !attached;
     }
 
     public void OnGrab(Transform grabParent)
     {
-        // Prevent grabbing a second badge once one is already attached
-        if (PlayerHeldBadge != null && PlayerHeldBadge != this)
-            return;
-
+        var inventory = grabParent.GetComponentInParent<Inventory>();
         var player = grabParent.GetComponentInParent<PlayerMovementController>();
 
         // Detect if we're stealing from an enemy
@@ -104,27 +108,24 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
 
         attached = true;
         rb.simulated = true;
+        if (inventory != null)
+        {
+            if (ownerInventory != null && ownerInventory != inventory)
+                ownerInventory.RemoveItem(PickupType.SecurityBadge);
+            inventory.SetItem(PickupType.SecurityBadge, this);
+            ownerInventory = inventory;
+        }
+
         if (player != null)
         {
-            // Attach directly to the player's hips
             var hip = player.BodyReference;
             if (hip != null)
-            {
-                PlayerHeldBadge = this;
-                heldByPlayer = true;
                 SetFollowTarget(hip.transform);
-
-                // Disable or destroy all other badges in the scene
-                foreach (var badge in FindObjectsByType<SecurityBadgePickup>(FindObjectsSortMode.None))
-                {
-                    if (badge != this)
-                        Destroy(badge.gameObject);
-                }
-            }
+            else
+                SetFollowTarget(grabParent);
         }
         else
         {
-            // Fallback: follow whatever grabbed us
             SetFollowTarget(grabParent);
         }
 
@@ -146,28 +147,21 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
         joint.enabled = false;
         followTarget = null;
 
-        if (heldByPlayer)
+        if (ownerInventory != null)
         {
-            heldByPlayer = false;
-            if (PlayerHeldBadge == this)
-                PlayerHeldBadge = null;
+            ownerInventory.RemoveItem(PickupType.SecurityBadge);
+            ownerInventory = null;
         }
 
         // // Give it some velocity so it flies off
         // rb.AddForce(throwForce * throwStrength, ForceMode2D.Impulse);
     }
 
-    private void OnDestroy()
+    /// <summary>
+    /// Sets the inventory that currently owns this pickup.
+    /// </summary>
+    public void AssignInventory(Inventory inventory)
     {
-        if (PlayerHeldBadge == this)
-            PlayerHeldBadge = null;
-    }
-
-    public static void DropPlayerBadge()
-    {
-        if (PlayerHeldBadge != null)
-        {
-            PlayerHeldBadge.OnRelease(Vector2.zero);
-        }
+        ownerInventory = inventory;
     }
 }


### PR DESCRIPTION
## Summary
- add new Inventory component keyed by pickup type
- use Inventory in PlayerMovementController and EnemyController
- refactor badge and battery pickups to consult holder inventory
- drop held items via Inventory on victory/character death
- adjust unit tests for new inventory logic

## Testing
- `bash setup_env.sh` *(fails: Package 'libasound2' has no installation candidate)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899e39186d4832491b2d98fe388bd5e