### PR TITLE
Improve grab detection to handle child colliders

### DIFF
--- a/Assets/Scripts/Player/GrabSystem/GrabHandAttractor.cs
+++ b/Assets/Scripts/Player/GrabSystem/GrabHandAttractor.cs
@@ -6,18 +6,46 @@ public class GrabHandAttractor : MonoBehaviour
     public LayerMask detectionLayer;
     public System.Action<IGrabbable> OnObjectDetected;
 
+    /// <summary>
+    /// Detects the closest grabbable object within range.
+    /// </summary>
     public IGrabbable DetectGrabbable()
     {
-        Collider2D col = Physics2D.OverlapCircle(transform.position, detectionRadius, detectionLayer);
-        if (col != null)
+        Collider2D[] cols = Physics2D.OverlapCircleAll(transform.position, detectionRadius, detectionLayer);
+        IGrabbable closestGrabbable = null;
+        float closestDistance = float.MaxValue;
+
+        foreach (Collider2D col in cols)
         {
-            IGrabbable grabbable = col.GetComponentInParent<IGrabbable>();
+            IGrabbable grabbable = col.GetComponent<IGrabbable>();
+            if (grabbable == null)
+            {
+                grabbable = col.GetComponentInParent<IGrabbable>();
+            }
+
             if (grabbable != null)
             {
-                OnObjectDetected?.Invoke(grabbable);
-                return grabbable;
+                MonoBehaviour grabbableMono = grabbable as MonoBehaviour;
+                if (grabbableMono == null)
+                {
+                    continue;
+                }
+
+                float distance = Vector2.Distance(transform.position, grabbableMono.transform.position);
+                if (distance < closestDistance)
+                {
+                    closestDistance = distance;
+                    closestGrabbable = grabbable;
+                }
             }
         }
+
+        if (closestGrabbable != null)
+        {
+            OnObjectDetected?.Invoke(closestGrabbable);
+            return closestGrabbable;
+        }
+
         return null;
     }
 }


### PR DESCRIPTION
## Summary
- Use `OverlapCircleAll` to check all nearby colliders for grabbable objects
- Detect grabbables on both the collider and its parents and pick the closest one

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899e68fc7fc83248d5bb46f19a4f7b4