### PR TITLE
Refactor CanBeGrabbed to depend on grabber inventory

### DIFF
--- a/Assets/Editor/UnitTests/BatteryPickupTests.cs
+++ b/Assets/Editor/UnitTests/BatteryPickupTests.cs
@@ -40,8 +40,14 @@ public class BatteryPickupTests
         battery.OnGrab(hand);
 
         Assert.AreEqual(60f, playerState.Stats.CurrentHealth);
-        Assert.IsFalse(battery.CanBeGrabbed());
+        Assert.IsTrue(battery.CanBeGrabbed(inventory));
         Assert.AreEqual(battery, inventory.GetItem(PickupType.Battery));
+
+        var otherInvGO = new GameObject("otherInv");
+        var otherInventory = otherInvGO.AddComponent<Inventory>();
+        otherInventory.SetItem(PickupType.Battery, new GameObject("otherBatt").AddComponent<BatteryPickup>());
+        Assert.IsFalse(battery.CanBeGrabbed(otherInventory));
+
         inventory.DropItem(PickupType.Battery);
         Assert.IsFalse(inventory.HasItem(PickupType.Battery));
     }

--- a/Assets/Editor/UnitTests/GrabHandAttractorTests.cs
+++ b/Assets/Editor/UnitTests/GrabHandAttractorTests.cs
@@ -6,7 +6,7 @@ public class GrabHandAttractorTests
 {
     private class DummyGrabbable : MonoBehaviour, IGrabbable
     {
-        public bool CanBeGrabbed() => true;
+        public bool CanBeGrabbed(Inventory inventory) => true;
         public void OnGrab(Transform grabParent) {}
         public void OnRelease(Vector2 throwForce) {}
         public void OnAttract(Vector2 attractPoint) {}

--- a/Assets/Editor/UnitTests/GrabSystemTests.cs
+++ b/Assets/Editor/UnitTests/GrabSystemTests.cs
@@ -42,7 +42,7 @@ public class GrabSystemTests
         public bool grabbed;
         public bool released;
         public Vector2 releasedForce;
-        public bool CanBeGrabbed() => true;
+        public bool CanBeGrabbed(Inventory inventory) => true;
         public void OnGrab(Transform grabParent)
         {
             grabbed = true;

--- a/Assets/Editor/UnitTests/SecurityBadgePickupTests.cs
+++ b/Assets/Editor/UnitTests/SecurityBadgePickupTests.cs
@@ -6,23 +6,30 @@ public class SecurityBadgePickupTests
     [Test]
     public void Badge_AttachAndReleaseChangesPhysics()
     {
-        var hand = new GameObject("hand").transform;
+        var handGO = new GameObject("hand");
+        var inventory = handGO.AddComponent<Inventory>();
+        var hand = handGO.transform;
         var obj = new GameObject("badge");
         var rb = obj.AddComponent<Rigidbody2D>();
         var badge = obj.AddComponent<SecurityBadgePickup>();
 
-        Assert.IsTrue(badge.CanBeGrabbed());
+        Assert.IsTrue(badge.CanBeGrabbed(inventory));
         badge.OnGrab(hand);
 
         var joint = obj.GetComponent<TargetJoint2D>();
         Assert.IsTrue(joint.enabled);
         Assert.AreEqual((Vector2)hand.position, joint.target);
-        Assert.IsFalse(badge.CanBeGrabbed());
+        Assert.IsTrue(badge.CanBeGrabbed(inventory));
+
+        var otherInvGO = new GameObject("otherInv");
+        var otherInventory = otherInvGO.AddComponent<Inventory>();
+        otherInventory.SetItem(PickupType.SecurityBadge, new GameObject("otherBadge").AddComponent<SecurityBadgePickup>());
+        Assert.IsFalse(badge.CanBeGrabbed(otherInventory));
 
         Vector2 throwForce = new Vector2(2f, 1f);
         badge.OnRelease(throwForce);
 
         Assert.IsFalse(joint.enabled);
-        Assert.IsTrue(badge.CanBeGrabbed());
+        Assert.IsTrue(badge.CanBeGrabbed(inventory));
     }
 }

--- a/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
@@ -59,20 +59,15 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
         }
     }
 
-    public bool CanBeGrabbed()
+    public bool CanBeGrabbed(Inventory inventory)
     {
-        var player = FindObjectOfType<PlayerMovementController>();
-        if (player != null)
+        if (inventory != null)
         {
-            var inventory = player.GetComponent<Inventory>();
-            if (inventory != null)
-            {
-                var held = inventory.GetItem(PickupType.Battery);
-                if (held != null && held != this)
-                    return false;
-            }
+            var held = inventory.GetItem(PickupType.Battery);
+            if (held != null && held != this)
+                return false;
         }
-        return !attached;
+        return true;
     }
 
     public void OnGrab(Transform grabParent)

--- a/Assets/Scripts/Player/GrabSystem/GrabSystem.cs
+++ b/Assets/Scripts/Player/GrabSystem/GrabSystem.cs
@@ -85,9 +85,9 @@ public class GrabSystem : MonoBehaviour
     {
         if (hand == null || held != null) return;
         IGrabbable obj = hand.DetectGrabbable();
-        if (obj != null && obj.CanBeGrabbed())
+        var inventory = hand.GetComponentInParent<Inventory>();
+        if (obj != null && obj.CanBeGrabbed(inventory))
         {
-            var inventory = hand.GetComponentInParent<Inventory>();
             PickupType? slot = null;
 
             if (obj is SecurityBadgePickup)

--- a/Assets/Scripts/Player/GrabSystem/HoldButton.cs
+++ b/Assets/Scripts/Player/GrabSystem/HoldButton.cs
@@ -7,7 +7,7 @@ public class HoldButton : MonoBehaviour, IGrabbable
     public UnityEvent OnReleased;
     private bool isHeld;
 
-    public bool CanBeGrabbed()
+    public bool CanBeGrabbed(Inventory inventory)
     {
         return true;
     }

--- a/Assets/Scripts/Player/GrabSystem/IGrabbable.cs
+++ b/Assets/Scripts/Player/GrabSystem/IGrabbable.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 public interface IGrabbable
 {
-    bool CanBeGrabbed();
+    bool CanBeGrabbed(Inventory inventory);
     void OnGrab(Transform grabParent);
     void OnRelease(Vector2 throwForce);
     void OnAttract(Vector2 attractPoint);

--- a/Assets/Scripts/Player/GrabSystem/LeverHandle.cs
+++ b/Assets/Scripts/Player/GrabSystem/LeverHandle.cs
@@ -15,7 +15,7 @@ public class LeverHandle : MonoBehaviour, IGrabbable
     private bool _isGrabbed;
     private float _currentT;
 
-    public bool CanBeGrabbed()
+    public bool CanBeGrabbed(Inventory inventory)
     {
         return true;
     }

--- a/Assets/Scripts/Player/GrabSystem/PickupBox.cs
+++ b/Assets/Scripts/Player/GrabSystem/PickupBox.cs
@@ -9,7 +9,7 @@ public class PickupBox : MonoBehaviour, IGrabbable
         if (rb == null) rb = GetComponent<Rigidbody2D>();
     }
 
-    public bool CanBeGrabbed()
+    public bool CanBeGrabbed(Inventory inventory)
     {
         return true;
     }

--- a/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
@@ -70,20 +70,15 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
         }
     }
 
-    public bool CanBeGrabbed()
+    public bool CanBeGrabbed(Inventory inventory)
     {
-        var player = FindObjectOfType<PlayerMovementController>();
-        if (player != null)
+        if (inventory != null)
         {
-            var inventory = player.GetComponent<Inventory>();
-            if (inventory != null)
-            {
-                var held = inventory.GetItem(PickupType.SecurityBadge);
-                if (held != null && held != this)
-                    return false;
-            }
+            var held = inventory.GetItem(PickupType.SecurityBadge);
+            if (held != null && held != this)
+                return false;
         }
-        return !attached;
+        return true;
     }
 
     public void OnGrab(Transform grabParent)


### PR DESCRIPTION
## Summary
- Rewrite security badge and battery pickups to consider only the grabber's inventory when determining if they can be grabbed
- Pass inventory into CanBeGrabbed from GrabSystem and update IGrabbable accordingly
- Extend tests for new CanBeGrabbed behavior and maintain health gain on battery pickup

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899edc555a083248824345d8ff28c49