### PR TITLE
Ensure batteries remain simulated after spawn and drop

### DIFF
--- a/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
@@ -129,6 +129,7 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
         attached = false;
         joint.enabled = false;
         followTarget = null;
+        rb.simulated = true;
 
         if (ownerInventory != null)
         {

--- a/Assets/Scripts/Services/BatterySpawner.cs
+++ b/Assets/Scripts/Services/BatterySpawner.cs
@@ -19,6 +19,12 @@ public class BatterySpawner : MonoBehaviour
             parent
         );
 
+        var rb = battery.GetComponent<Rigidbody2D>();
+        if (rb != null)
+        {
+            rb.simulated = true;
+        }
+
         battery.SetFollowTarget(parent);
 
         return battery;


### PR DESCRIPTION
## Summary
- Activate Rigidbody2D simulation for spawned battery pickups
- Keep dropped batteries simulated so they remain grabbable

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899f81f10548324959e622274e429c3