### PR TITLE
Ensure battery layer applied on spawn

### DIFF
--- a/Assets/Scripts/Services/BatterySpawner.cs
+++ b/Assets/Scripts/Services/BatterySpawner.cs
@@ -19,6 +19,8 @@ public class BatterySpawner : MonoBehaviour
             parent
         );
 
+        battery.gameObject.layer = LayerMask.NameToLayer("Battery");
+
         var rb = battery.GetComponent<Rigidbody2D>();
         if (rb != null)
         {


### PR DESCRIPTION
## Summary
- verify GrabHandAttractor uses layers BadgeSecurity, Battery and CubeUpgrade for detection
- force spawned batteries onto the Battery layer to guarantee detection

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899fa53c4c08324b6f533950d344d3d