### PR TITLE
Add GrabSystem battery theft unit test

### DIFF
--- a/Assets/Editor/UnitTests/BatteryStealFromEnemyTests.cs
+++ b/Assets/Editor/UnitTests/BatteryStealFromEnemyTests.cs
@@ -1,0 +1,109 @@
+using NUnit.Framework;
+using UnityEngine;
+using System.Reflection;
+
+public class BatteryStealFromEnemyTests
+{
+    private class DummyInput : MonoBehaviour, IPlayerInput
+    {
+        public Vector2 Movement => Vector2.zero;
+        public bool JumpPressed => false;
+        public bool PrimaryAttack => false;
+        public bool LeftGrabDown  { get; private set; }
+        public bool LeftGrabHeld  { get; private set; }
+        public bool LeftGrabUp    { get; private set; }
+        public bool RightGrabDown => LeftGrabDown;
+        public bool RightGrabHeld => LeftGrabHeld;
+        public bool RightGrabUp   => LeftGrabUp;
+        public void PressGrab()
+        {
+            LeftGrabDown = true;
+            LeftGrabHeld = true;
+        }
+        public void NextFrame()
+        {
+            LeftGrabDown = false;
+            LeftGrabUp = false;
+        }
+    }
+
+    private class DummyPlayerMovementController : PlayerMovementController
+    {
+        void Awake() { }
+        void OnEnable() { }
+        void Update() { }
+    }
+
+    [Test]
+    public void StealBattery_TransfersInventoryAndDamagesEnemy()
+    {
+        // Enemy with battery
+        var enemyGO = new GameObject("enemy");
+        enemyGO.AddComponent<EnergyBot>();
+        enemyGO.AddComponent<HealthBot>();
+        var enemyState = enemyGO.AddComponent<RobotStateController>();
+        enemyState.Stats = new RobotStats();
+        enemyState.Stats.MaxHealth = 100f;
+        enemyState.Stats.CurrentHealth = 50f;
+        enemyGO.AddComponent<EnemyStateMachine>();
+        var enemy = enemyGO.AddComponent<EnemyController>();
+        enemy.EnemyStatus = EnemyStatus.Idle;
+        var enemyInventory = enemyGO.GetComponent<Inventory>();
+
+        var batteryGO = new GameObject("battery");
+        batteryGO.transform.SetParent(enemyGO.transform);
+        batteryGO.AddComponent<Rigidbody2D>();
+        batteryGO.AddComponent<TargetJoint2D>();
+        batteryGO.AddComponent<CircleCollider2D>();
+        var battery = batteryGO.AddComponent<BatteryPickup>();
+        battery.AssignInventory(enemyInventory);
+        enemyInventory.SetItem(PickupType.Battery, battery);
+
+        // Player with grab system
+        var playerGO = new GameObject("player");
+        playerGO.AddComponent<EnergyBot>();
+        playerGO.AddComponent<HealthBot>();
+        var playerState = playerGO.AddComponent<RobotStateController>();
+        playerState.Stats = new RobotStats();
+        playerState.Stats.MaxHealth = 100f;
+        playerState.Stats.CurrentHealth = 40f;
+        var playerRb = playerGO.AddComponent<Rigidbody2D>();
+        var player = playerGO.AddComponent<DummyPlayerMovementController>();
+        var playerInventory = playerGO.AddComponent<Inventory>();
+        typeof(PlayerMovementController)
+            .GetField("bodyReference", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(player, playerRb);
+
+        var handObj = new GameObject("hand");
+        handObj.transform.SetParent(playerGO.transform);
+        var hand = handObj.AddComponent<GrabHandAttractor>();
+        hand.detectionRadius = 1f;
+        int layer = 8;
+        hand.detectionLayer = 1 << layer;
+        batteryGO.layer = layer;
+        batteryGO.transform.position = handObj.transform.position;
+
+        var grabSystem = playerGO.AddComponent<GrabSystem>();
+        grabSystem.leftHand = hand;
+        var inputObj = new GameObject("input");
+        var input = inputObj.AddComponent<DummyInput>();
+        typeof(GrabSystem)
+            .GetField("inputSource", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(grabSystem, input);
+        typeof(GrabSystem)
+            .GetMethod("Awake", BindingFlags.NonPublic | BindingFlags.Instance)
+            .Invoke(grabSystem, null);
+
+        Assert.IsTrue(enemyInventory.HasItem(PickupType.Battery));
+        Assert.IsFalse(playerInventory.HasItem(PickupType.Battery));
+
+        input.PressGrab();
+        grabSystem.Update();
+        input.NextFrame();
+
+        Assert.AreEqual(battery, playerInventory.GetItem(PickupType.Battery));
+        Assert.IsFalse(enemyInventory.HasItem(PickupType.Battery));
+        Assert.AreEqual(40f + 10f, playerState.Stats.CurrentHealth);
+        Assert.AreEqual(50f - 10f, enemyState.Stats.CurrentHealth);
+    }
+}

--- a/Assets/Editor/UnitTests/BatteryStealFromEnemyTests.cs.meta
+++ b/Assets/Editor/UnitTests/BatteryStealFromEnemyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0ccd7439cd7e4cabbc12aadc4f407ace


### PR DESCRIPTION
## Summary
- add BatteryStealFromEnemyTests verifying that grabbing a battery from an enemy via GrabSystem moves it to the player, removes it from the enemy, and damages the enemy

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*
- `apt-get install -y unity` *(attempted; prompts for keyboard configuration and does not install Unity test runner)*

------
https://chatgpt.com/codex/tasks/task_e_6899fa560a28832492ff6275ea00e0e9