### PR TITLE
Prevent inventory DropAll collection modification error

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -66,9 +66,10 @@ public class Inventory : MonoBehaviour
     /// </summary>
     public void DropAll()
     {
-        foreach (var kvp in items)
+        var itemsToDrop = new List<IGrabbable>(items.Values);
+        foreach (var item in itemsToDrop)
         {
-            kvp.Value.OnRelease(Vector2.zero);
+            item?.OnRelease(Vector2.zero);
         }
         items.Clear();
     }


### PR DESCRIPTION
## Summary
- Avoid modifying the inventory dictionary while iterating by iterating over a snapshot when dropping all items

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found: unity)*

------
https://chatgpt.com/codex/tasks/task_e_689a62d1b8e88324bd15a28be17af939