### PR TITLE
Rename Empty usage type to Work

### DIFF
--- a/Assets/Editor/UnitTests/CellPropertiesTests.cs
+++ b/Assets/Editor/UnitTests/CellPropertiesTests.cs
@@ -20,7 +20,7 @@ public class CellPropertiesTests
         Assert.IsFalse(_props.HasRightDoorLocked);
         Assert.IsFalse(_props.HasLiftUpBlocked);
         Assert.IsFalse(_props.HasLiftDownBlocked);
-        Assert.AreEqual(UsageType.Empty, _props.usageType);
+        Assert.AreEqual(UsageType.Work, _props.usageType);
         Assert.AreEqual(POIType.None, _props.poiType);
     }
 }

--- a/Assets/Editor/UnitTests/MapManagerTests.cs
+++ b/Assets/Editor/UnitTests/MapManagerTests.cs
@@ -82,17 +82,17 @@ public class MapManagerTests
     }
 
     [Test]
-    public void GetRandomEmptyPosition_ReturnsPosition()
+    public void GetRandomWorkPosition_ReturnsPosition()
     {
-        var emptyGO = new GameObject();
-        emptyGO.transform.position = new Vector3(3, 0, 0);
-        var props = emptyGO.AddComponent<RoomProperties>();
-        props.usageType = UsageType.Empty;
-        var dict = new System.Collections.Generic.Dictionary<Vector2, GameObject> { { Vector2.zero, emptyGO } };
+        var workGO = new GameObject();
+        workGO.transform.position = new Vector3(3, 0, 0);
+        var props = workGO.AddComponent<RoomProperties>();
+        props.usageType = UsageType.Work;
+        var dict = new System.Collections.Generic.Dictionary<Vector2, GameObject> { { Vector2.zero, workGO } };
         typeof(MapManager).GetField("roomInstances", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(_manager, dict);
 
-        var pos = _manager.GetRandomEmptyPosition();
-        Assert.AreEqual(emptyGO.transform.position, pos);
+        var pos = _manager.GetRandomWorkPosition();
+        Assert.AreEqual(workGO.transform.position, pos);
     }
 
     private class DummyGridBuilder : IGridBuilder

--- a/Assets/Editor/UnitTests/RoomLiftPerFloorProcessorTests.cs
+++ b/Assets/Editor/UnitTests/RoomLiftPerFloorProcessorTests.cs
@@ -15,30 +15,30 @@ public class RoomLiftPerFloorProcessorTests
 
         var blocked = new Cell(new Vector2(0, 1), UsageType.Blocked);
         var poi = new Cell(new Vector2(1, 1), UsageType.POI);
-        var empty = new Cell(new Vector2(2, 1), UsageType.Empty);
+        var work = new Cell(new Vector2(2, 1), UsageType.Work);
         grid[blocked.position] = blocked;
         grid[poi.position] = poi;
-        grid[empty.position] = empty;
+        grid[work.position] = work;
 
         var poi2 = new Cell(new Vector2(0, 2), UsageType.POI);
-        var empty2 = new Cell(new Vector2(1, 2), UsageType.Empty);
+        var work2 = new Cell(new Vector2(1, 2), UsageType.Work);
         grid[poi2.position] = poi2;
-        grid[empty2.position] = empty2;
+        grid[work2.position] = work2;
 
-        var empty3 = new Cell(new Vector2(0, 3), UsageType.Empty);
-        grid[empty3.position] = empty3;
+        var work3 = new Cell(new Vector2(0, 3), UsageType.Work);
+        grid[work3.position] = work3;
 
         var processor = new RoomLiftPerFloorProcessor(3, 4);
         processor.ProcessCells(grid);
 
         Assert.AreEqual(UsageType.PathToPOI, blocked.cellProperties.usageType);
         Assert.AreEqual(UsageType.POI, poi.cellProperties.usageType);
-        Assert.AreEqual(UsageType.Empty, empty.cellProperties.usageType);
+        Assert.AreEqual(UsageType.Work, work.cellProperties.usageType);
 
         Assert.AreEqual(UsageType.PathToPOI, poi2.cellProperties.usageType);
-        Assert.AreEqual(UsageType.Empty, empty2.cellProperties.usageType);
+        Assert.AreEqual(UsageType.Work, work2.cellProperties.usageType);
 
-        Assert.AreEqual(UsageType.PathToPOI, empty3.cellProperties.usageType);
+        Assert.AreEqual(UsageType.PathToPOI, work3.cellProperties.usageType);
         Assert.AreEqual(UsageType.PathToPOI, existingPath.cellProperties.usageType);
     }
 

--- a/Assets/Resources/Prefabs/Map/MapManager.prefab
+++ b/Assets/Resources/Prefabs/Map/MapManager.prefab
@@ -54,4 +54,4 @@ MonoBehaviour:
   receptionPOI_Prefab: {fileID: 542146199199913260, guid: 3d6b903f23f088d4ab161eccb58e9190, type: 3}
   securityPOI_Prefab: {fileID: 542146199199913260, guid: 61ec338c4d025b14eb781d8691fbccd7, type: 3}
   pathToPOIPrefab: {fileID: 542146199199913260, guid: 1c5027646d87732499c2adfeec1f8233, type: 3}
-  emptyPrefab: {fileID: 542146199199913260, guid: 698d313749aa0524a957563038d9f5cf, type: 3}
+  workPrefab: {fileID: 542146199199913260, guid: 698d313749aa0524a957563038d9f5cf, type: 3}

--- a/Assets/Scripts/Managers/EnemiesSpawner.cs
+++ b/Assets/Scripts/Managers/EnemiesSpawner.cs
@@ -259,9 +259,9 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
 
     public void SpawnEnemyAtRandom()
     {
-        // Example: spawn a NEW worker at a random empty cell
+        // Example: spawn a NEW worker at a random work cell
         var go = PoolGet(workerPrefab);
-        var pos = mapManager.GetRandomEmptyPosition();
+        var pos = mapManager.GetRandomWorkPosition();
 
         PrepareSkeleton(go);
         PositionAndWake(go, pos);
@@ -279,7 +279,7 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
     public void SpawnBossAtRandom()
     {
         var go = PoolGet(bossPrefab);
-        var pos = mapManager.GetRandomEmptyPosition();
+        var pos = mapManager.GetRandomWorkPosition();
 
         PrepareSkeleton(go);
         PositionAndWake(go, pos);

--- a/Assets/Scripts/Map/WaypointService.cs
+++ b/Assets/Scripts/Map/WaypointService.cs
@@ -144,7 +144,7 @@ public class WaypointService : MonoBehaviour, IWaypointService
         var works = registry
             .GetActiveWaypoints()
             .Where(wp =>
-                wp.parentRoom.roomProperties.usageType == UsageType.Empty
+                wp.parentRoom.roomProperties.usageType == UsageType.Work
                 && wp.type == WaypointType.Work
                 && wp.parentRoom.factorymMachinesInRoom.Any(m =>
                     m.IsOn && m.CurrentWorker == null && !reservedMachines.ContainsKey(m)
@@ -159,7 +159,7 @@ public class WaypointService : MonoBehaviour, IWaypointService
             works = registry
                 .GetActiveWaypoints()
                 .Where(wp =>
-                    wp.parentRoom.roomProperties.usageType == UsageType.Empty
+                    wp.parentRoom.roomProperties.usageType == UsageType.Work
                     && wp.type == WaypointType.Work
                     && wp.parentRoom.factorymMachinesInRoom.Any(m =>
                         m.IsOn && m.CurrentWorker != null
@@ -174,7 +174,7 @@ public class WaypointService : MonoBehaviour, IWaypointService
             works = registry
                 .GetActiveWaypoints()
                 .Where(wp =>
-                    wp.parentRoom.roomProperties.usageType == UsageType.Empty
+                    wp.parentRoom.roomProperties.usageType == UsageType.Work
                     && wp.type == WaypointType.Work
                     && wp.parentRoom.factorymMachinesInRoom.Any(m => m.IsOn)
                     && wp != exclude
@@ -192,7 +192,7 @@ public class WaypointService : MonoBehaviour, IWaypointService
                 : 1;
             reservedWaypoints.Add(best);
             Debug.Log(
-                $"[WaypointReservation] Assigned EMPTY WORK '{best.WorldPos}' (count={workUsageCounts[best]})."
+                $"[WaypointReservation] Assigned WORK '{best.WorldPos}' (count={workUsageCounts[best]})."
             );
             return best;
         }
@@ -205,7 +205,7 @@ public class WaypointService : MonoBehaviour, IWaypointService
         var works = registry
             .GetActiveWaypoints()
             .Where(wp =>
-                wp.parentRoom.roomProperties.usageType == UsageType.Empty
+                wp.parentRoom.roomProperties.usageType == UsageType.Work
                 && wp.type == WaypointType.Work
                 && wp != exclude
                 && !reservedWaypoints.Contains(wp)
@@ -222,7 +222,7 @@ public class WaypointService : MonoBehaviour, IWaypointService
                 : 1;
             reservedWaypoints.Add(best);
             Debug.Log(
-                $"[WaypointReservation] Assigned EMPTY WORK '{best.WorldPos}' (count={workUsageCounts[best]})."
+                $"[WaypointReservation] Assigned WORK '{best.WorldPos}' (count={workUsageCounts[best]})."
             );
             return best;
         }

--- a/Assets/Scripts/Navigation/Cell.cs
+++ b/Assets/Scripts/Navigation/Cell.cs
@@ -7,7 +7,7 @@ public class Cell
 
     public int fCost, gCost, hCost;
 
-    public Cell(Vector2 pos, UsageType usageType = UsageType.Empty)
+    public Cell(Vector2 pos, UsageType usageType = UsageType.Work)
     {
         position = pos;
         gCost = int.MaxValue;

--- a/Assets/Scripts/Navigation/GridFactory.cs
+++ b/Assets/Scripts/Navigation/GridFactory.cs
@@ -17,7 +17,7 @@ public class GridFactory
         {
             for (int y = 0; y < height; y++)
             {
-                var cell = new Cell(new Vector2(x, y), UsageType.Empty);
+                var cell = new Cell(new Vector2(x, y), UsageType.Work);
                 cell.cellProperties.GridPosition = new Vector2Int(x, y);
                 cell.cellProperties.poiType = POIType.None;
                 grid[new Vector2(x, y)] = cell;
@@ -42,9 +42,9 @@ public class GridFactory
         // Exclude start and end positions from POI candidates
         var excluded = new HashSet<Vector2> { startPosition, endPosition };
 
-        // Collect all eligible positions (empty cells only)
+        // Collect all eligible positions (work cells only)
         var eligibleCells = cellDataGrid
-            .Where(kvp => kvp.Value.cellProperties.usageType == UsageType.Empty && !excluded.Contains(kvp.Key))
+            .Where(kvp => kvp.Value.cellProperties.usageType == UsageType.Work && !excluded.Contains(kvp.Key))
             .Select(kvp => kvp.Key)
             .ToList();
 
@@ -82,23 +82,23 @@ public class GridFactory
 
     public void AssignBlockedCells(int wallCount)
     {
-        // 1. Collect all empty cells
-        var emptyCells = cellDataGrid.Values
-            .Where(cell => cell.cellProperties.usageType == UsageType.Empty)
+        // 1. Collect all work cells
+        var workCells = cellDataGrid.Values
+            .Where(cell => cell.cellProperties.usageType == UsageType.Work)
             .ToList();
 
         // 2. Shuffle the list
-        for (int i = emptyCells.Count - 1; i > 0; i--)
+        for (int i = workCells.Count - 1; i > 0; i--)
         {
             int j = Random.Range(0, i + 1);
-            var temp = emptyCells[i];
-            emptyCells[i] = emptyCells[j];
-            emptyCells[j] = temp;
+            var temp = workCells[i];
+            workCells[i] = workCells[j];
+            workCells[j] = temp;
         }
 
         // 3. Assign blocked type to the first wallCount cells
         int blockedCount = 0;
-        foreach (var cell in emptyCells)
+        foreach (var cell in workCells)
         {
             if (blockedCount >= wallCount)
                 break;
@@ -134,7 +134,7 @@ public class GridFactory
                 poiPaths[i] = path;
                 foreach (var pos in path)
                 {
-                    if (cellDataGrid[pos].cellProperties.usageType == UsageType.Empty)
+                    if (cellDataGrid[pos].cellProperties.usageType == UsageType.Work)
                         cellDataGrid[pos].cellProperties.usageType = UsageType.PathToPOI;
                 }
             }

--- a/Assets/Scripts/Navigation/MapManager.cs
+++ b/Assets/Scripts/Navigation/MapManager.cs
@@ -23,7 +23,7 @@ public class MapManager : MonoBehaviour
     [SerializeField] private GameObject receptionPOI_Prefab;
     [SerializeField] private GameObject securityPOI_Prefab;
     [SerializeField] private GameObject pathToPOIPrefab;
-    [SerializeField] private GameObject emptyPrefab;
+    [SerializeField] private GameObject workPrefab;
 
     // ---------------------------------------------------------------- Instances & services
     private Dictionary<Vector2, GameObject> roomInstances;
@@ -151,7 +151,7 @@ public class MapManager : MonoBehaviour
             new Vector2(cellWidth, cellHeight),
             transform.position,
             transform,
-            emptyPrefab);
+            workPrefab);
 
         gridManager.AssignRoomProperties(roomInstances, cellDataGrid);
     }
@@ -168,7 +168,7 @@ public class MapManager : MonoBehaviour
             { UsageType.End,       endPrefab       },
             { UsageType.POI,       defaultPOI_Prefab},
             { UsageType.PathToPOI, pathToPOIPrefab },
-            { UsageType.Empty,     emptyPrefab     },
+            { UsageType.Work,      workPrefab      },
         };
     }
 
@@ -245,33 +245,33 @@ public class MapManager : MonoBehaviour
         return poiPos;
     }
     
-    private List<Vector3> unusedEmptyPositions = new List<Vector3>();
-    public Vector3 GetRandomEmptyPosition()
+    private List<Vector3> unusedWorkPositions = new List<Vector3>();
+    public Vector3 GetRandomWorkPosition()
     {
         if (roomInstances == null)
             return Vector3.zero;
 
-        // Populate unusedEmptyPositions if empty
-        if (unusedEmptyPositions.Count == 0)
+        // Populate unusedWorkPositions if empty
+        if (unusedWorkPositions.Count == 0)
         {
-            unusedEmptyPositions = roomInstances.Values
+            unusedWorkPositions = roomInstances.Values
                 .Select(roomObj => roomObj.GetComponent<RoomProperties>())
-                .Where(roomProps => roomProps != null && roomProps.usageType == UsageType.Empty)
+                .Where(roomProps => roomProps != null && roomProps.usageType == UsageType.Work)
                 .Select(roomProps => roomProps.gameObject.transform.position)
                 .ToList();
 
-            if (unusedEmptyPositions.Count == 0)
+            if (unusedWorkPositions.Count == 0)
             {
-                Debug.LogWarning("No Empty cells found in roomInstances.");
+                Debug.LogWarning("No Work cells found in roomInstances.");
                 return Vector3.zero;
             }
         }
 
-        // Pick a random Empty from the unused list
-        int idx = UnityEngine.Random.Range(0, unusedEmptyPositions.Count);
-        Vector3 EmptyPos = unusedEmptyPositions[idx];
-        unusedEmptyPositions.RemoveAt(idx);
-        return EmptyPos;
+        // Pick a random Work cell from the unused list
+        int idx = UnityEngine.Random.Range(0, unusedWorkPositions.Count);
+        Vector3 workPos = unusedWorkPositions[idx];
+        unusedWorkPositions.RemoveAt(idx);
+        return workPos;
     }
 
 }

--- a/Assets/Scripts/Navigation/RoomLiftPerFloorProcessor.cs
+++ b/Assets/Scripts/Navigation/RoomLiftPerFloorProcessor.cs
@@ -123,12 +123,12 @@ public class RoomLiftPerFloorProcessor : CellProcessor
         if (c == null) return false;
 
         // Adjust this whitelist to your project’s enum:
-        // We avoid overwriting Start/End/Doors/etc. Keep what you had (Blocked/POI/Empty) plus any "WORK" mapping if needed.
-        var t = c.cellProperties.usageType;
-        return t == UsageType.Empty
-            || t == UsageType.Blocked
-            || t == UsageType.POI
-            || t == UsageType.PathToPOI; // allow aligning existing lifts too
+          // We avoid overwriting Start/End/Doors/etc. Keep what you had (Blocked/POI/Work) plus any "WORK" mapping if needed.
+          var t = c.cellProperties.usageType;
+          return t == UsageType.Work
+              || t == UsageType.Blocked
+              || t == UsageType.POI
+              || t == UsageType.PathToPOI; // allow aligning existing lifts too
     }
 
     private void SetLift(Cell c)

--- a/Assets/Scripts/Navigation/UsageType.cs
+++ b/Assets/Scripts/Navigation/UsageType.cs
@@ -1,6 +1,6 @@
 public enum UsageType
 {
-    Empty,
+    Work,
     Blocked,
     Start,
     End,

--- a/Assets/Scripts/UI/RunSetupManager.cs
+++ b/Assets/Scripts/UI/RunSetupManager.cs
@@ -258,13 +258,13 @@ public class RunSetupManager : MonoBehaviour
         if (poi + blocked > cellsAvailable) isValid = false;
 
         // 3) Ensure enemy count ≤ (cellsAvailable - poi - blocked)
-        int emptyCells = cellsAvailable - poi - blocked;
+        int workCells = cellsAvailable - poi - blocked;
 
         // Highlight si erreur
         void Mark(VisualElement f, bool ok) => f.style.borderBottomColor = ok ? Color.clear : Color.red;
         Mark(poiField, poi + blocked <= cellsAvailable);
         Mark(blockedField, poi + blocked <= cellsAvailable);
-        Mark(workersCountField, workers <= emptyCells);
+        Mark(workersCountField, workers <= workCells);
 
         if (!isValid)
         {


### PR DESCRIPTION
## Summary
- rename `UsageType.Empty` enum value to `UsageType.Work`
- rename map-related prefab and methods from `empty` to `work`
- update comments, logs, and UI to reference work rooms/cells

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*
- `apt-get install -y unity-editor` *(fails: Unable to locate package unity-editor)*

------
https://chatgpt.com/codex/tasks/task_e_689a6bd25e2c83248de3397f295a0483