### PR TITLE
Faint boss when all machines shut down

### DIFF
--- a/Assets/Scripts/Managers/EnemiesSpawner.cs
+++ b/Assets/Scripts/Managers/EnemiesSpawner.cs
@@ -52,6 +52,9 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
         this.securityBadgeSpawner = securityBadgeSpawner;
         this.batterySpawner = batterySpawner;
 
+        if (this.securityManager != null)
+            this.securityManager.OnAllMachinesOff += HandleAllMachinesOff;
+
         if (respawnService is RobotRespawnService service)
             service.Initialize(this);
 
@@ -339,5 +342,24 @@ public class EnemiesSpawner : MonoBehaviour, IEnemiesSpawner, IDropHost
             legLimiter.RefreshJoints();
             legLimiter.enabled = true;
         }
+    }
+
+    private void HandleAllMachinesOff()
+    {
+        var enemies = FindObjectsOfType<EnemyController>();
+        foreach (var enemy in enemies)
+        {
+            if (enemy != null && enemy.IsBoss)
+            {
+                enemy.Faint();
+                break;
+            }
+        }
+    }
+
+    private void OnDestroy()
+    {
+        if (securityManager != null)
+            securityManager.OnAllMachinesOff -= HandleAllMachinesOff;
     }
 }


### PR DESCRIPTION
## Summary
- Handle MachineSecurityManager's OnAllMachinesOff event in EnemiesSpawner
- Faint the boss when all machines are off
- Unsubscribe from event on destroy

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae465fcc08324add8b0b62757507b