### PR TITLE
Add cube conveyor controller

### DIFF
--- a/Assets/Scripts/Machines/CubeConveyorController.cs
+++ b/Assets/Scripts/Machines/CubeConveyorController.cs
@@ -1,0 +1,68 @@
+using System;
+using UnityEngine;
+
+public class CubeConveyorController : MonoBehaviour
+{
+    [SerializeField] private Transform spawnPoint;
+    [SerializeField] private Transform exitPoint;
+    [SerializeField] private Transform midpointTrigger;
+    [SerializeField] private float speed = 1f;
+    [SerializeField] private CubeSpawner cubeSpawner;
+
+    private CubePickup currentCube;
+    private bool midpointActivated = false;
+
+    public event Action OnCubeProcessed;
+
+    /// <summary>
+    /// Spawns a cube and begins moving it along the conveyor.
+    /// </summary>
+    public void BeginConveyor()
+    {
+        if (cubeSpawner == null || spawnPoint == null)
+        {
+            Debug.LogWarning("CubeConveyorController: Missing references.");
+            return;
+        }
+
+        currentCube = cubeSpawner.SpawnCube(spawnPoint);
+        if (currentCube == null)
+            return;
+
+        var rb = currentCube.GetComponent<Rigidbody2D>();
+        if (rb != null)
+            rb.bodyType = RigidbodyType2D.Kinematic;
+
+        midpointActivated = false;
+    }
+
+    private void Update()
+    {
+        if (currentCube == null)
+            return;
+
+        var cubeTransform = currentCube.transform;
+
+        // Move cube towards the exit.
+        cubeTransform.position = Vector2.MoveTowards(
+            cubeTransform.position,
+            exitPoint.position,
+            speed * Time.deltaTime);
+
+        // Check for midpoint activation.
+        if (!midpointActivated && midpointTrigger != null && cubeTransform.position.x >= midpointTrigger.position.x)
+        {
+            currentCube.SendMessage("Activate", SendMessageOptions.DontRequireReceiver);
+            midpointActivated = true;
+        }
+
+        // Check if cube reached exit or was detached.
+        if (Vector2.Distance(cubeTransform.position, exitPoint.position) < 0.01f || cubeTransform.parent != spawnPoint)
+        {
+            Destroy(currentCube.gameObject);
+            currentCube = null;
+            midpointActivated = false;
+            OnCubeProcessed?.Invoke();
+        }
+    }
+}

--- a/Assets/Scripts/Machines/CubeConveyorController.cs.meta
+++ b/Assets/Scripts/Machines/CubeConveyorController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fffc712bbd0f4623b25d65d9616a382e


### PR DESCRIPTION
## Summary
- add CubeConveyorController to spawn and move cubes along conveyor
- fire event after cube reaches exit or is detached

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae60775ac8324869f7d4104cfbd35