### PR TITLE
Add conveyor cube upgrade activation

### DIFF
--- a/Assets/Scripts/Machines/ConveyorCube.cs
+++ b/Assets/Scripts/Machines/ConveyorCube.cs
@@ -1,0 +1,58 @@
+using System;
+using UnityEngine;
+
+public enum CubeUpgradeType
+{
+    MaxHealth,
+    MaxEnergy,
+    EnergyRecharge,
+    AttackDamage
+}
+
+public class ConveyorCube : MonoBehaviour
+{
+    [SerializeField] private Sprite maxHealthSprite;
+    [SerializeField] private Sprite maxEnergySprite;
+    [SerializeField] private Sprite energyRechargeSprite;
+    [SerializeField] private Sprite attackDamageSprite;
+    [SerializeField] private SpriteRenderer spriteRenderer;
+
+    private enum CubeState { Normal, Active }
+    private CubeState state = CubeState.Normal;
+
+    /// <summary>
+    /// Gets the upgrade type selected when activated.
+    /// </summary>
+    public CubeUpgradeType SelectedUpgrade { get; private set; }
+
+    /// <summary>
+    /// Randomly selects an upgrade type and updates the sprite.
+    /// </summary>
+    public void Activate()
+    {
+        if (state == CubeState.Active)
+            return;
+
+        Array values = Enum.GetValues(typeof(CubeUpgradeType));
+        SelectedUpgrade = (CubeUpgradeType)values.GetValue(UnityEngine.Random.Range(0, values.Length));
+
+        switch (SelectedUpgrade)
+        {
+            case CubeUpgradeType.MaxHealth:
+                spriteRenderer.sprite = maxHealthSprite;
+                break;
+            case CubeUpgradeType.MaxEnergy:
+                spriteRenderer.sprite = maxEnergySprite;
+                break;
+            case CubeUpgradeType.EnergyRecharge:
+                spriteRenderer.sprite = energyRechargeSprite;
+                break;
+            case CubeUpgradeType.AttackDamage:
+                spriteRenderer.sprite = attackDamageSprite;
+                break;
+        }
+
+        state = CubeState.Active;
+    }
+}
+

--- a/Assets/Scripts/Machines/ConveyorCube.cs.meta
+++ b/Assets/Scripts/Machines/ConveyorCube.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dfc698cb89374e83a3c08762d256803c


### PR DESCRIPTION
## Summary
- introduce `CubeUpgradeType` enum and `ConveyorCube` component
- allow conveyor cubes to randomly select an upgrade and change sprite when activated

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae72106c0832488f047959cfc01fd