### PR TITLE
Avoid releasing stolen pickups on enemy death

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -201,17 +201,23 @@ public class EnemyController : PhysicsBaseAgentController, IPooledObject
     {
         if (initialBadge != null)
         {
-            initialBadge.OnRelease(Vector2.zero);
-            if (dropContainer != null)
-                initialBadge.transform.SetParent(dropContainer, true);
+            if (inventory != null && inventory.GetItem(PickupType.SecurityBadge) == initialBadge)
+            {
+                initialBadge.OnRelease(Vector2.zero);
+                if (dropContainer != null)
+                    initialBadge.transform.SetParent(dropContainer, true);
+            }
             initialBadge = null;
         }
 
         if (initialBattery != null)
         {
-            initialBattery.OnRelease(Vector2.zero);
-            if (dropContainer != null)
-                initialBattery.transform.SetParent(dropContainer, true);
+            if (inventory != null && inventory.GetItem(PickupType.Battery) == initialBattery)
+            {
+                initialBattery.OnRelease(Vector2.zero);
+                if (dropContainer != null)
+                    initialBattery.transform.SetParent(dropContainer, true);
+            }
             initialBattery = null;
         }
     }


### PR DESCRIPTION
## Summary
- Prevent EnemyController from releasing stolen badge or battery pickups on death unless still owned by its inventory

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*
- `apt-get install -y unity-editor` *(fails: Unable to locate package unity-editor)*

------
https://chatgpt.com/codex/tasks/task_e_689af5a669a4832499cdcbd2822c8d4f