### PR TITLE
Queue next cube after processing

### DIFF
--- a/Assets/Scripts/Machines/FactoryMachine.cs
+++ b/Assets/Scripts/Machines/FactoryMachine.cs
@@ -115,6 +115,7 @@ public class FactoryMachine : BaseMachine
     private void HandleCubeProcessed()
     {
         cubeActive = false;
+        ScheduleSpawn();
     }
 
     private void ScheduleSpawn()


### PR DESCRIPTION
## Summary
- ensure new cubes spawn after processing by scheduling spawns when conveyor finishes

## Testing
- `bash setup_env.sh` *(fails: Package 'libasound2' has no installation candidate)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found: unity)*

------
https://chatgpt.com/codex/tasks/task_e_689afa31d5fc83248bf64d677d29bfed