### PR TITLE
feat: add cube collector upgrade storage

### DIFF
--- a/Assets/Editor/UnitTests/CubeCollectorTests.cs
+++ b/Assets/Editor/UnitTests/CubeCollectorTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+
+public class CubeCollectorTests
+{
+    [Test]
+    public void CollectorStoresUpgradeFromCube()
+    {
+        var upgradeSO = ScriptableObject.CreateInstance<CubeUpgradeSO>();
+
+        var collectorGO = new GameObject("collector");
+        collectorGO.AddComponent<BoxCollider2D>();
+        var collector = collectorGO.AddComponent<CubeCollector>();
+        typeof(CubeCollector)
+            .GetField("upgradeStore", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(collector, upgradeSO);
+
+        var cubeGO = new GameObject("cube");
+        cubeGO.AddComponent<Rigidbody2D>();
+        cubeGO.AddComponent<TargetJoint2D>();
+        cubeGO.AddComponent<CubePickup>();
+        var conveyor = cubeGO.AddComponent<ConveyorCube>();
+        var cubeCollider = cubeGO.AddComponent<BoxCollider2D>();
+
+        typeof(ConveyorCube)
+            .GetField("<SelectedUpgrade>k__BackingField", BindingFlags.Instance | BindingFlags.NonPublic)
+            .SetValue(conveyor, CubeUpgradeType.AttackDamage);
+
+        var method = typeof(CubeCollector)
+            .GetMethod("OnTriggerEnter2D", BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Invoke(collector, new object[] { cubeCollider });
+
+        Assert.AreEqual(CubeUpgradeType.AttackDamage, upgradeSO.SelectedUpgrade);
+    }
+}
+

--- a/Assets/Editor/UnitTests/CubeCollectorTests.cs.meta
+++ b/Assets/Editor/UnitTests/CubeCollectorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f34b73bd350149e9b0fb009f2f31c48d

--- a/Assets/Scripts/Machines/CubeCollector.cs
+++ b/Assets/Scripts/Machines/CubeCollector.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+/// <summary>
+/// Collects conveyor cubes and stores their upgrade.
+/// Requires a trigger Collider2D.
+/// </summary>
+[RequireComponent(typeof(Collider2D))]
+public class CubeCollector : MonoBehaviour
+{
+    [SerializeField] private CubeUpgradeSO upgradeStore;
+
+    private void Awake()
+    {
+        Collider2D collider = GetComponent<Collider2D>();
+        if (collider != null)
+        {
+            collider.isTrigger = true;
+        }
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (other == null)
+            return;
+
+        CubePickup pickup = other.GetComponent<CubePickup>();
+        ConveyorCube cube = other.GetComponent<ConveyorCube>();
+
+        if (pickup != null && cube != null && upgradeStore != null)
+        {
+            upgradeStore.Store(cube.SelectedUpgrade);
+        }
+    }
+}
+

--- a/Assets/Scripts/Machines/CubeCollector.cs.meta
+++ b/Assets/Scripts/Machines/CubeCollector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6350df1f9d87488384d18ab751b17262

--- a/Assets/Scripts/ScriptObjects/CubeUpgradeSO.cs
+++ b/Assets/Scripts/ScriptObjects/CubeUpgradeSO.cs
@@ -1,0 +1,54 @@
+using UnityEngine;
+
+/// <summary>
+/// Stores a cube upgrade and can apply it to robot stats.
+/// </summary>
+[CreateAssetMenu(fileName = "CubeUpgrade", menuName = "Upgrades/CubeUpgrade")]
+public class CubeUpgradeSO : ScriptableObject
+{
+    [SerializeField] private CubeUpgradeType selectedUpgrade;
+
+    /// <summary>
+    /// Gets the stored upgrade type.
+    /// </summary>
+    public CubeUpgradeType SelectedUpgrade => selectedUpgrade;
+
+    /// <summary>
+    /// Stores the provided upgrade type.
+    /// </summary>
+    /// <param name="upgrade">Upgrade obtained from a cube.</param>
+    public void Store(CubeUpgradeType upgrade)
+    {
+        selectedUpgrade = upgrade;
+    }
+
+    /// <summary>
+    /// Applies the stored upgrade to the target stats.
+    /// </summary>
+    /// <param name="target">Stats to receive the upgrade.</param>
+    public void ApplyUpgrade(RobotStats target)
+    {
+        if (target == null)
+            return;
+
+        switch (selectedUpgrade)
+        {
+            case CubeUpgradeType.MaxHealth:
+                target.MaxHealth += 1f;
+                target.UpdateHealth(1f);
+                break;
+            case CubeUpgradeType.MaxEnergy:
+                target.MaxEnergy += 1f;
+                target.UpdateEnergy(1f);
+                break;
+            case CubeUpgradeType.EnergyRecharge:
+                target.UpdateEnergy(1f);
+                break;
+            case CubeUpgradeType.AttackDamage:
+                foreach (Attack attack in target.Attacks)
+                    attack.Damage += 1;
+                break;
+        }
+    }
+}
+

--- a/Assets/Scripts/ScriptObjects/CubeUpgradeSO.cs.meta
+++ b/Assets/Scripts/ScriptObjects/CubeUpgradeSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a05dc1541d42468f89e0e04d536789ca


### PR DESCRIPTION
## Summary
- add CubeCollector that records conveyor cube upgrades
- add CubeUpgradeSO ScriptableObject to store and apply upgrades
- test CubeCollector stores upgrade when cube enters trigger

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689afdda575083249d52353577d382cb