### PR TITLE
feat: add upgrade cube spawning

### DIFF
--- a/Assets/Resources/Prefabs/intereableObjects/CubeSpawner.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/CubeSpawner.prefab
@@ -42,6 +42,10 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 05c90c2f4fc74534694d7c5b3e322169, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  cubePrefab: {fileID: -3281786584640236443, guid: 965968b2004a3024dbf6cf8534199579, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  normalCubePrefab: {fileID: -3281786584640236443, guid: 965968b2004a3024dbf6cf8534199579, type: 3}
+  upgradeCubePrefabs:
+  - {fileID: -3281786584640236443, guid: 5eae2a5d019b88a468fe542a5e503e66, type: 3}
+  - {fileID: -3281786584640236443, guid: 9bc7a386174f6d14bb442ecd98983b61, type: 3}
+  - {fileID: -3281786584640236443, guid: 7582993ae06bd514f890146089f13a4e, type: 3}

--- a/Assets/Scripts/Machines/CubeConveyorController.cs
+++ b/Assets/Scripts/Machines/CubeConveyorController.cs
@@ -57,7 +57,23 @@ public class CubeConveyorController : MonoBehaviour
         // Check for midpoint activation.
         if (!midpointActivated && midpointTrigger != null && cubeTransform.position.x >= midpointTrigger.position.x)
         {
-            currentCube.SendMessage("Activate", SendMessageOptions.DontRequireReceiver);
+            if (cubeSpawner != null)
+            {
+                Transform parent = currentCube.transform.parent;
+                Vector3 position = currentCube.transform.position;
+
+                currentCube.OnGrabbed -= HandleCubeGrabbed;
+                Destroy(currentCube.gameObject);
+
+                currentCube = cubeSpawner.SpawnRandomUpgrade(parent, position);
+                if (currentCube != null)
+                {
+                    currentCube.OnGrabbed += HandleCubeGrabbed;
+                    var rbNew = currentCube.GetComponent<Rigidbody2D>();
+                    if (rbNew != null)
+                        rbNew.bodyType = RigidbodyType2D.Kinematic;
+                }
+            }
             midpointActivated = true;
         }
 

--- a/Assets/Scripts/Services/CubeSpawner.cs
+++ b/Assets/Scripts/Services/CubeSpawner.cs
@@ -2,28 +2,51 @@ using UnityEngine;
 
 public class CubeSpawner : MonoBehaviour
 {
-    [SerializeField] private CubePickup cubePrefab;
+    [SerializeField] private CubePickup normalCubePrefab;
+    [SerializeField] private CubePickup[] upgradeCubePrefabs;
 
+    /// <summary>
+    /// Instantiates the normal cube prefab at the provided parent.
+    /// </summary>
+    /// <param name="parent">Transform to parent the cube to.</param>
+    /// <returns>The spawned cube.</returns>
     public CubePickup SpawnCube(Transform parent)
     {
-        if (cubePrefab == null)
+        return InstantiateCube(normalCubePrefab, parent, parent.position, parent.rotation);
+    }
+
+    /// <summary>
+    /// Replaces a cube with a randomly selected upgrade cube.
+    /// </summary>
+    /// <param name="parent">Parent transform for the new cube.</param>
+    /// <param name="position">Spawn position for the new cube.</param>
+    /// <returns>The spawned upgrade cube, or null if none were available.</returns>
+    public CubePickup SpawnRandomUpgrade(Transform parent, Vector3 position)
+    {
+        if (upgradeCubePrefabs == null || upgradeCubePrefabs.Length == 0)
         {
-            Debug.LogWarning("CubeSpawner: cubePrefab is null!");
+            Debug.LogWarning("CubeSpawner: upgradeCubePrefabs array is empty!");
             return null;
         }
 
-        Vector3 spawnPos = parent.position;
-        spawnPos.z = 0.01f;
+        int index = Random.Range(0, upgradeCubePrefabs.Length);
+        CubePickup prefab = upgradeCubePrefabs[index];
 
-        var cube = Instantiate(
-            cubePrefab,
-            spawnPos,
-            parent.rotation,
-            parent
-        );
+        return InstantiateCube(prefab, parent, position, parent.rotation);
+    }
 
+    private CubePickup InstantiateCube(CubePickup prefab, Transform parent, Vector3 position, Quaternion rotation)
+    {
+        if (prefab == null)
+        {
+            Debug.LogWarning("CubeSpawner: cube prefab is null!");
+            return null;
+        }
+
+        position.z = 0.01f;
+
+        CubePickup cube = Instantiate(prefab, position, rotation, parent);
         cube.SetFollowTarget(parent);
-
         return cube;
     }
 }


### PR DESCRIPTION
## Summary
- allow CubeSpawner to spawn normal and random upgrade cubes
- swap normal conveyor cube for random upgrade at midpoint
- configure CubeSpawner prefab with health, energy, and energy-recharge cubes

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b0acc77988324a5fa448680b38c5d