### PR TITLE
Apply cube upgrades to player and record run stats

### DIFF
--- a/Assets/Scripts/Machines/CubeCollector.cs
+++ b/Assets/Scripts/Machines/CubeCollector.cs
@@ -29,6 +29,15 @@ public class CubeCollector : MonoBehaviour
         if (pickup != null && cube != null && upgradeStore != null)
         {
             upgradeStore.Store(cube.SelectedUpgrade);
+
+            RobotStats playerStats = other.GetComponentInParent<RobotStateController>()?.Stats;
+            if (playerStats != null)
+            {
+                upgradeStore.ApplyUpgrade(playerStats);
+                RunProgressManager.Instance?.RunStats?.Capture(playerStats);
+            }
+
+            Destroy(pickup.gameObject);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Apply collected cube upgrades immediately to the player's RobotStats
- Capture updated player stats for persistence across levels
- Destroy collected cube to avoid repeated triggers

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1195388883249bee615bef9eb382