### PR TITLE
feat: track cube upgrade state

### DIFF
--- a/Assets/Resources/Prefabs/intereableObjects/CubeAttackDamage.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/CubeAttackDamage.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 6206929599146606855}
   - component: {fileID: 7876967260955353992}
   - component: {fileID: 2933447607757072381}
+  - component: {fileID: 7240392201043162271}
   - component: {fileID: -3281786584640236443}
   m_Layer: 13
   m_Name: CubeAttackDamage
@@ -184,6 +185,25 @@ BoxCollider2D:
   m_AutoTiling: 0
   m_Size: {x: 0.35778987, y: 0.35349166}
   m_EdgeRadius: 0
+--- !u!114 &7240392201043162271
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1934608487537832627}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfc698cb89374e83a3c08762d256803c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  maxHealthSprite: {fileID: 0}
+  maxEnergySprite: {fileID: 0}
+  energyRechargeSprite: {fileID: 0}
+  attackDamageSprite: {fileID: 0}
+  spriteRenderer: {fileID: 6374700015707614389}
+  isUpgradeActive: 0
+  upgradeType: 3
 --- !u!114 &-3281786584640236443
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/intereableObjects/CubeMaxEnergy.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/CubeMaxEnergy.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 6206929599146606855}
   - component: {fileID: 7876967260955353992}
   - component: {fileID: 2933447607757072381}
+  - component: {fileID: 7240392201043162272}
   - component: {fileID: -3281786584640236443}
   m_Layer: 13
   m_Name: CubeMaxEnergy
@@ -184,6 +185,25 @@ BoxCollider2D:
   m_AutoTiling: 0
   m_Size: {x: 0.35778987, y: 0.35349166}
   m_EdgeRadius: 0
+--- !u!114 &7240392201043162272
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1934608487537832627}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfc698cb89374e83a3c08762d256803c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  maxHealthSprite: {fileID: 0}
+  maxEnergySprite: {fileID: 0}
+  energyRechargeSprite: {fileID: 0}
+  attackDamageSprite: {fileID: 0}
+  spriteRenderer: {fileID: 6374700015707614389}
+  isUpgradeActive: 0
+  upgradeType: 1
 --- !u!114 &-3281786584640236443
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/intereableObjects/CubeMaxHealth.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/CubeMaxHealth.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 6206929599146606855}
   - component: {fileID: 7876967260955353992}
   - component: {fileID: 2933447607757072381}
+  - component: {fileID: 7240392201043162273}
   - component: {fileID: -3281786584640236443}
   m_Layer: 13
   m_Name: CubeMaxHealth
@@ -184,6 +185,25 @@ BoxCollider2D:
   m_AutoTiling: 0
   m_Size: {x: 0.35778987, y: 0.35349166}
   m_EdgeRadius: 0
+--- !u!114 &7240392201043162273
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1934608487537832627}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfc698cb89374e83a3c08762d256803c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  maxHealthSprite: {fileID: 0}
+  maxEnergySprite: {fileID: 0}
+  energyRechargeSprite: {fileID: 0}
+  attackDamageSprite: {fileID: 0}
+  spriteRenderer: {fileID: 6374700015707614389}
+  isUpgradeActive: 0
+  upgradeType: 0
 --- !u!114 &-3281786584640236443
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/intereableObjects/CubeNormal.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/CubeNormal.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 6206929599146606855}
   - component: {fileID: 7876967260955353992}
   - component: {fileID: 2933447607757072381}
+  - component: {fileID: 7240392201043162274}
   - component: {fileID: -3281786584640236443}
   m_Layer: 13
   m_Name: CubeNormal
@@ -184,6 +185,25 @@ BoxCollider2D:
   m_AutoTiling: 0
   m_Size: {x: 0.35778987, y: 0.35349166}
   m_EdgeRadius: 0
+--- !u!114 &7240392201043162274
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1934608487537832627}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfc698cb89374e83a3c08762d256803c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  maxHealthSprite: {fileID: 0}
+  maxEnergySprite: {fileID: 0}
+  energyRechargeSprite: {fileID: 0}
+  attackDamageSprite: {fileID: 0}
+  spriteRenderer: {fileID: 6374700015707614389}
+  isUpgradeActive: 0
+  upgradeType: 0
 --- !u!114 &-3281786584640236443
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/intereableObjects/CubeReloadEnergy.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/CubeReloadEnergy.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 6206929599146606855}
   - component: {fileID: 7876967260955353992}
   - component: {fileID: 2933447607757072381}
+  - component: {fileID: 7240392201043162275}
   - component: {fileID: -3281786584640236443}
   m_Layer: 13
   m_Name: CubeReloadEnergy
@@ -184,6 +185,25 @@ BoxCollider2D:
   m_AutoTiling: 0
   m_Size: {x: 0.35778987, y: 0.35349166}
   m_EdgeRadius: 0
+--- !u!114 &7240392201043162275
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1934608487537832627}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dfc698cb89374e83a3c08762d256803c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  maxHealthSprite: {fileID: 0}
+  maxEnergySprite: {fileID: 0}
+  energyRechargeSprite: {fileID: 0}
+  attackDamageSprite: {fileID: 0}
+  spriteRenderer: {fileID: 6374700015707614389}
+  isUpgradeActive: 0
+  upgradeType: 2
 --- !u!114 &-3281786584640236443
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Machines/ConveyorCube.cs
+++ b/Assets/Scripts/Machines/ConveyorCube.cs
@@ -17,6 +17,9 @@ public class ConveyorCube : MonoBehaviour
     [SerializeField] private Sprite attackDamageSprite;
     [SerializeField] private SpriteRenderer spriteRenderer;
 
+    public bool isUpgradeActive = false;
+    public CubeUpgradeType upgradeType;
+
     private enum CubeState { Normal, Active }
     private CubeState state = CubeState.Normal;
 
@@ -26,15 +29,15 @@ public class ConveyorCube : MonoBehaviour
     public CubeUpgradeType SelectedUpgrade { get; private set; }
 
     /// <summary>
-    /// Randomly selects an upgrade type and updates the sprite.
+    /// Activates the cube's configured upgrade and updates the sprite.
     /// </summary>
     public void Activate()
     {
         if (state == CubeState.Active)
             return;
 
-        Array values = Enum.GetValues(typeof(CubeUpgradeType));
-        SelectedUpgrade = (CubeUpgradeType)values.GetValue(UnityEngine.Random.Range(0, values.Length));
+        isUpgradeActive = true;
+        SelectedUpgrade = upgradeType;
 
         switch (SelectedUpgrade)
         {


### PR DESCRIPTION
## Summary
- add upgrade state and type fields to `ConveyorCube`
- mark cubes as upgraded when activated
- attach `ConveyorCube` script to cube prefabs with specific upgrade types

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b1fc808c08324a50f643fdbd0ce41