### PR TITLE
Track cube upgrades in run stats

### DIFF
--- a/Assets/Editor/UnitTests/CubeCollectorTests.cs
+++ b/Assets/Editor/UnitTests/CubeCollectorTests.cs
@@ -34,5 +34,49 @@ public class CubeCollectorTests
         Assert.AreEqual(CubeUpgradeType.AttackDamage, upgradeSO.SelectedUpgrade);
         Assert.IsTrue(pickup == null);
     }
+
+    [Test]
+    public void CollectorIncrementsRunStats()
+    {
+        var upgradeSO = ScriptableObject.CreateInstance<CubeUpgradeSO>();
+        var runStats = ScriptableObject.CreateInstance<PlayerRunStats>();
+
+        var sceneControllerGO = new GameObject("sceneController");
+        sceneControllerGO.AddComponent<SceneController>();
+
+        var rpmGO = new GameObject("runManager");
+        var rpm = rpmGO.AddComponent<RunProgressManager>();
+        typeof(RunProgressManager)
+            .GetField("runStats", BindingFlags.Instance | BindingFlags.NonPublic)
+            .SetValue(rpm, runStats);
+
+        var collectorGO = new GameObject("collector");
+        collectorGO.AddComponent<BoxCollider2D>();
+        var collector = collectorGO.AddComponent<CubeCollector>();
+        typeof(CubeCollector)
+            .GetField("upgradeStore", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(collector, upgradeSO);
+
+        var cubeGO = new GameObject("cube");
+        cubeGO.AddComponent<Rigidbody2D>();
+        cubeGO.AddComponent<TargetJoint2D>();
+        cubeGO.AddComponent<EnergyBot>();
+        cubeGO.AddComponent<HealthBot>();
+        var controller = cubeGO.AddComponent<RobotStateController>();
+        controller.Stats = new RobotStats();
+        var pickup = cubeGO.AddComponent<CubePickup>();
+        var upgrade = cubeGO.AddComponent<CubeUpgrade>();
+        var cubeCollider = cubeGO.AddComponent<BoxCollider2D>();
+
+        typeof(CubeUpgrade)
+            .GetField("upgradeType", BindingFlags.Instance | BindingFlags.NonPublic)
+            .SetValue(upgrade, CubeUpgradeType.MaxHealth);
+
+        var method = typeof(CubeCollector)
+            .GetMethod("OnTriggerEnter2D", BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Invoke(collector, new object[] { cubeCollider });
+
+        Assert.AreEqual(upgradeSO.UpgradeMaxHealthValue, runStats.MaxHealthBonus);
+    }
 }
 

--- a/Assets/Scripts/Machines/CubeCollector.cs
+++ b/Assets/Scripts/Machines/CubeCollector.cs
@@ -31,10 +31,31 @@ public class CubeCollector : MonoBehaviour
             upgradeStore.Store(cube.UpgradeType);
 
             RobotStats playerStats = other.GetComponentInParent<RobotStateController>()?.Stats;
+            PlayerRunStats runStats = RunProgressManager.Instance?.RunStats;
             if (playerStats != null)
             {
+                if (runStats != null)
+                {
+                    switch (cube.UpgradeType)
+                    {
+                        case CubeUpgradeType.MaxHealth:
+                            runStats.MaxHealthBonus += upgradeStore.UpgradeMaxHealthValue;
+                            break;
+                        case CubeUpgradeType.MaxEnergy:
+                            runStats.MaxEnergyBonus += upgradeStore.UpgradeMaxEnergyValue;
+                            break;
+                        case CubeUpgradeType.EnergyRecharge:
+                            // No direct property on PlayerRunStats yet; placeholder for future logic
+                            break;
+        
+                        case CubeUpgradeType.AttackDamage:
+                            runStats.AttackDamageBonus += upgradeStore.UpgradeAttackDamageValue;
+                            break;
+                    }
+                }
+
                 upgradeStore.ApplyUpgrade(playerStats);
-                RunProgressManager.Instance?.RunStats?.Capture(playerStats);
+                runStats?.Capture(playerStats);
             }
 
             Destroy(pickup.gameObject);

--- a/Assets/Scripts/Machines/CubeUpgradeSO.cs
+++ b/Assets/Scripts/Machines/CubeUpgradeSO.cs
@@ -13,6 +13,25 @@ public class CubeUpgradeSO : ScriptableObject
     [SerializeField] private float upgradeEnergyRechargeValue = 5f;
     [SerializeField] private int upgradeAttackDamageValue = 5;
 
+    /// <summary>
+    /// Value added to MaxHealth when upgrading.
+    /// </summary>
+    public float UpgradeMaxHealthValue => upgradeMaxHealthValue;
+
+    /// <summary>
+    /// Value added to MaxEnergy when upgrading.
+    /// </summary>
+    public float UpgradeMaxEnergyValue => upgradeMaxEnergyValue;
+
+    /// <summary>
+    /// Value added to energy recharge when upgrading.
+    /// </summary>
+    public float UpgradeEnergyRechargeValue => upgradeEnergyRechargeValue;
+
+    /// <summary>
+    /// Value added to attack damage when upgrading.
+    /// </summary>
+    public int UpgradeAttackDamageValue => upgradeAttackDamageValue;
 
     /// <summary>
     /// Gets the stored upgrade type.

--- a/Assets/Scripts/Player/Data/PlayerRunStats.cs
+++ b/Assets/Scripts/Player/Data/PlayerRunStats.cs
@@ -3,8 +3,11 @@ using UnityEngine;
 [CreateAssetMenu(fileName = "PlayerRunStats", menuName = "Player/RunStats")]
 public class PlayerRunStats : ScriptableObject
 {
-    public float currentHealth;
-    public float morality;
+    public float CurrentHealth;
+    public float Morality;
+    public float MaxHealthBonus;
+    public float MaxEnergyBonus;
+    public int AttackDamageBonus;
     private bool hasValues;
 
     public bool HasValues => hasValues;
@@ -20,13 +23,13 @@ public class PlayerRunStats : ScriptableObject
             return;
         }
 
-        currentHealth = Mathf.Clamp(source.CurrentHealth, 0f, source.MaxHealth);
-        morality = source.Morality;
+        CurrentHealth = Mathf.Clamp(source.CurrentHealth, 0f, source.MaxHealth);
+        Morality = source.Morality;
         hasValues = true;
     }
 
     /// <summary>
-    /// Applies captured stats to the target robot.
+    /// Applies captured stats and accumulated upgrades to the target robot.
     /// </summary>
     /// <param name="target">Robot receiving stored values.</param>
     public void Apply(RobotStats target)
@@ -36,9 +39,16 @@ public class PlayerRunStats : ScriptableObject
             return;
         }
 
-        float healthTarget = Mathf.Clamp(currentHealth, 0f, target.MaxHealth);
+        target.MaxHealth += MaxHealthBonus;
+        target.MaxEnergy += MaxEnergyBonus;
+        foreach (Attack attack in target.Attacks)
+        {
+            attack.Damage += AttackDamageBonus;
+        }
+
+        float healthTarget = Mathf.Clamp(CurrentHealth, 0f, target.MaxHealth);
         target.UpdateHealth(healthTarget - target.CurrentHealth);
-        target.UpdateMorality(morality - target.Morality);
+        target.UpdateMorality(Morality - target.Morality);
     }
 
     /// <summary>
@@ -46,8 +56,11 @@ public class PlayerRunStats : ScriptableObject
     /// </summary>
     public void Reset()
     {
-        currentHealth = 0f;
-        morality = 0f;
+        CurrentHealth = 0f;
+        Morality = 0f;
+        MaxHealthBonus = 0f;
+        MaxEnergyBonus = 0f;
+        AttackDamageBonus = 0;
         hasValues = false;
     }
 }


### PR DESCRIPTION
## Summary
- store health, energy, and damage bonuses in PlayerRunStats
- expose upgrade value getters in CubeUpgradeSO
- apply cube upgrade values directly to PlayerRunStats in CubeCollector and keep capture fallback
- add unit test validating run stats increment

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b25b0e77c8324a36bff47871cd492