### PR TITLE
feat: expand player run stats

### DIFF
--- a/Assets/Scripts/Game/LevelEndTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndTrigger.cs
@@ -45,7 +45,9 @@ public class LevelEndTrigger : MonoBehaviour
 
             if (runStats != null && controller != null)
             {
-                runStats.Capture(controller.Stats);
+                EnergyBot energyBot = controller.GetComponent<EnergyBot>();
+                Attack attack = controller.Stats.Attacks.Count > 0 ? controller.Stats.Attacks[0] : null;
+                runStats.Capture(controller.Stats, energyBot, attack);
                 if (saveService != null)
                 {
                     saveService.SaveGame(controller);

--- a/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
@@ -59,7 +59,9 @@ public class LevelEndVictoryTrigger : MonoBehaviour
 
                 if (runStats != null && controller != null)
                 {
-                    runStats.Capture(controller.Stats);
+                    EnergyBot energyBot = controller.GetComponent<EnergyBot>();
+                    Attack attack = controller.Stats.Attacks.Count > 0 ? controller.Stats.Attacks[0] : null;
+                    runStats.Capture(controller.Stats, energyBot, attack);
                     if (saveService != null)
                     {
                         saveService.SaveGame(controller);

--- a/Assets/Scripts/Player/Core/PlayerSpawner.cs
+++ b/Assets/Scripts/Player/Core/PlayerSpawner.cs
@@ -46,7 +46,9 @@ public class PlayerSpawner : MonoBehaviour, IPlayerSpawner
         // Apply stats before gameplay so HUD and AI use updated values
         if (runStats != null && runStats.HasValues)
         {
-            runStats.Apply(playerRobotInfo);
+            EnergyBot energyBot = playerInstance.GetComponent<EnergyBot>();
+            Attack attack = playerRobotInfo.Attacks.Count > 0 ? playerRobotInfo.Attacks[0] : null;
+            runStats.Apply(playerRobotInfo, energyBot, attack);
         }
 
         // Locate "WholeBody" container

--- a/Assets/Scripts/Player/Data/PlayerRunStats.cs
+++ b/Assets/Scripts/Player/Data/PlayerRunStats.cs
@@ -4,16 +4,22 @@ using UnityEngine;
 public class PlayerRunStats : ScriptableObject
 {
     public float currentHealth;
+    public float maxHealth;
+    public float maxEnergy;
+    public float energyRechargeRate;
+    public int attackDamage;
     public float morality;
     private bool hasValues;
 
     public bool HasValues => hasValues;
 
     /// <summary>
-    /// Captures temporary stats from the source robot.
+    /// Captures temporary stats from the source robot and related systems.
     /// </summary>
     /// <param name="source">Robot providing current values.</param>
-    public void Capture(RobotStats source)
+    /// <param name="energyBot">Energy system supplying recharge rate.</param>
+    /// <param name="attack">Attack providing damage values.</param>
+    public void Capture(RobotStats source, EnergyBot energyBot, Attack attack)
     {
         if (source == null)
         {
@@ -21,24 +27,46 @@ public class PlayerRunStats : ScriptableObject
         }
 
         currentHealth = Mathf.Clamp(source.CurrentHealth, 0f, source.MaxHealth);
+        maxHealth = source.MaxHealth;
+        maxEnergy = source.MaxEnergy;
         morality = source.Morality;
+        if (energyBot != null)
+        {
+            energyRechargeRate = energyBot.rechargeRate;
+        }
+        if (attack != null)
+        {
+            attackDamage = attack.Damage;
+        }
         hasValues = true;
     }
 
     /// <summary>
-    /// Applies captured stats to the target robot.
+    /// Applies captured stats to the target robot and related systems.
     /// </summary>
     /// <param name="target">Robot receiving stored values.</param>
-    public void Apply(RobotStats target)
+    /// <param name="energyBot">Energy system to update recharge rate.</param>
+    /// <param name="attack">Attack to update with stored damage.</param>
+    public void Apply(RobotStats target, EnergyBot energyBot, Attack attack)
     {
         if (target == null || !hasValues)
         {
             return;
         }
 
+        target.MaxHealth = maxHealth;
+        target.MaxEnergy = maxEnergy;
         float healthTarget = Mathf.Clamp(currentHealth, 0f, target.MaxHealth);
         target.UpdateHealth(healthTarget - target.CurrentHealth);
         target.UpdateMorality(morality - target.Morality);
+        if (energyBot != null)
+        {
+            energyBot.rechargeRate = energyRechargeRate;
+        }
+        if (attack != null)
+        {
+            attack.Damage = attackDamage;
+        }
     }
 
     /// <summary>
@@ -47,6 +75,10 @@ public class PlayerRunStats : ScriptableObject
     public void Reset()
     {
         currentHealth = 0f;
+        maxHealth = 0f;
+        maxEnergy = 0f;
+        energyRechargeRate = 0f;
+        attackDamage = 0;
         morality = 0f;
         hasValues = false;
     }


### PR DESCRIPTION
## Summary
- extend `PlayerRunStats` with max health, max energy, energy recharge rate and attack damage
- capture and apply new stats in level end triggers and player spawner

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b238639a48324903b5ce6ed75855c