### PR TITLE
Enable energy recharge upgrade and tests

### DIFF
--- a/Assets/Editor/UnitTests/CubeCollectorTests.cs
+++ b/Assets/Editor/UnitTests/CubeCollectorTests.cs
@@ -78,5 +78,49 @@ public class CubeCollectorTests
 
         Assert.AreEqual(upgradeSO.UpgradeMaxHealthValue, runStats.MaxHealthBonus);
     }
+
+    [Test]
+    public void CollectorIncrementsEnergyRechargeRunStats()
+    {
+        var upgradeSO = ScriptableObject.CreateInstance<CubeUpgradeSO>();
+        var runStats = ScriptableObject.CreateInstance<PlayerRunStats>();
+
+        var sceneControllerGO = new GameObject("sceneController");
+        sceneControllerGO.AddComponent<SceneController>();
+
+        var rpmGO = new GameObject("runManager");
+        var rpm = rpmGO.AddComponent<RunProgressManager>();
+        typeof(RunProgressManager)
+            .GetField("runStats", BindingFlags.Instance | BindingFlags.NonPublic)
+            .SetValue(rpm, runStats);
+
+        var collectorGO = new GameObject("collector");
+        collectorGO.AddComponent<BoxCollider2D>();
+        var collector = collectorGO.AddComponent<CubeCollector>();
+        typeof(CubeCollector)
+            .GetField("upgradeStore", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(collector, upgradeSO);
+
+        var cubeGO = new GameObject("cube");
+        cubeGO.AddComponent<Rigidbody2D>();
+        cubeGO.AddComponent<TargetJoint2D>();
+        cubeGO.AddComponent<EnergyBot>();
+        cubeGO.AddComponent<HealthBot>();
+        var controller = cubeGO.AddComponent<RobotStateController>();
+        controller.Stats = new RobotStats();
+        var pickup = cubeGO.AddComponent<CubePickup>();
+        var upgrade = cubeGO.AddComponent<CubeUpgrade>();
+        var cubeCollider = cubeGO.AddComponent<BoxCollider2D>();
+
+        typeof(CubeUpgrade)
+            .GetField("upgradeType", BindingFlags.Instance | BindingFlags.NonPublic)
+            .SetValue(upgrade, CubeUpgradeType.EnergyRecharge);
+
+        var method = typeof(CubeCollector)
+            .GetMethod("OnTriggerEnter2D", BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Invoke(collector, new object[] { cubeCollider });
+
+        Assert.AreEqual(upgradeSO.UpgradeEnergyRechargeValue, runStats.EnergyRechargeBonus);
+    }
 }
 

--- a/Assets/Editor/UnitTests/CubeUpgradeSOTests.cs
+++ b/Assets/Editor/UnitTests/CubeUpgradeSOTests.cs
@@ -1,0 +1,19 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class CubeUpgradeSOTests
+{
+    [Test]
+    public void ApplyUpgrade_IncreasesEnergyRechargeRate()
+    {
+        var upgradeSO = ScriptableObject.CreateInstance<CubeUpgradeSO>();
+        upgradeSO.Store(CubeUpgradeType.EnergyRecharge);
+
+        var stats = new RobotStats();
+        float initialRate = stats.EnergyRechargeRate;
+
+        upgradeSO.ApplyUpgrade(stats);
+
+        Assert.AreEqual(initialRate + upgradeSO.UpgradeEnergyRechargeValue, stats.EnergyRechargeRate);
+    }
+}

--- a/Assets/Editor/UnitTests/CubeUpgradeSOTests.cs.meta
+++ b/Assets/Editor/UnitTests/CubeUpgradeSOTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 222ed5740fdf4874bf1adca4ea7fd3d2

--- a/Assets/Scripts/Machines/CubeCollector.cs
+++ b/Assets/Scripts/Machines/CubeCollector.cs
@@ -45,9 +45,9 @@ public class CubeCollector : MonoBehaviour
                             runStats.MaxEnergyBonus += upgradeStore.UpgradeMaxEnergyValue;
                             break;
                         case CubeUpgradeType.EnergyRecharge:
-                            // No direct property on PlayerRunStats yet; placeholder for future logic
+                            runStats.EnergyRechargeBonus += upgradeStore.UpgradeEnergyRechargeValue;
                             break;
-        
+
                         case CubeUpgradeType.AttackDamage:
                             runStats.AttackDamageBonus += upgradeStore.UpgradeAttackDamageValue;
                             break;

--- a/Assets/Scripts/Machines/CubeUpgradeSO.cs
+++ b/Assets/Scripts/Machines/CubeUpgradeSO.cs
@@ -66,10 +66,10 @@ public class CubeUpgradeSO : ScriptableObject
                 target.MaxEnergy += upgradeMaxEnergyValue;
                 target.UpdateEnergy(upgradeMaxEnergyValue);
                 break;
-            // case CubeUpgradeType.EnergyRecharge:
-            // target.EnergyRechargeRate += upgradeEnergyRechargeValue;
-            //     target.UpdateEnergyRecharge(upgradeEnergyRechargeValue);
-            //     break;
+            case CubeUpgradeType.EnergyRecharge:
+                target.EnergyRechargeRate += upgradeEnergyRechargeValue;
+                target.UpdateEnergyRecharge(upgradeEnergyRechargeValue);
+                break;
             case CubeUpgradeType.AttackDamage:
                 foreach (Attack attack in target.Attacks)
                     attack.Damage += upgradeAttackDamageValue;

--- a/Assets/Scripts/Player/Data/PlayerRunStats.cs
+++ b/Assets/Scripts/Player/Data/PlayerRunStats.cs
@@ -9,6 +9,10 @@ public class PlayerRunStats : ScriptableObject
     public float energyRechargeRate;
     public int attackDamage;
     public float morality;
+    public float MaxHealthBonus;
+    public float MaxEnergyBonus;
+    public float EnergyRechargeBonus;
+    public int AttackDamageBonus;
 
     private bool hasValues;
 
@@ -30,16 +34,15 @@ public class PlayerRunStats : ScriptableObject
         maxHealth = source.MaxHealth;
         maxEnergy = source.MaxEnergy;
         morality = source.Morality;
-        if (energyBot != null)
-        {
-            energyRechargeRate = energyBot.rechargeRate;
-        }
-        if (attack != null)
-        {
-            attackDamage = attack.Damage;
-        }
+        energyRechargeRate = energyBot != null ? energyBot.rechargeRate : source.EnergyRechargeRate;
+        attackDamage = attack != null ? attack.Damage : (source.Attacks.Count > 0 ? source.Attacks[0].Damage : 0);
 
         hasValues = true;
+    }
+
+    public void Capture(RobotStats source)
+    {
+        Capture(source, null, null);
     }
 
     /// <summary>
@@ -61,6 +64,7 @@ public class PlayerRunStats : ScriptableObject
         float healthTarget = Mathf.Clamp(currentHealth, 0f, target.MaxHealth);
         target.UpdateHealth(healthTarget - target.CurrentHealth);
         target.UpdateMorality(morality - target.Morality);
+        target.EnergyRechargeRate = energyRechargeRate;
         if (energyBot != null)
         {
             energyBot.rechargeRate = energyRechargeRate;
@@ -69,7 +73,6 @@ public class PlayerRunStats : ScriptableObject
         {
             attack.Damage = attackDamage;
         }
-
     }
 
     /// <summary>
@@ -83,6 +86,10 @@ public class PlayerRunStats : ScriptableObject
         energyRechargeRate = 0f;
         attackDamage = 0;
         morality = 0f;
+        MaxHealthBonus = 0f;
+        MaxEnergyBonus = 0f;
+        EnergyRechargeBonus = 0f;
+        AttackDamageBonus = 0;
 
         hasValues = false;
     }

--- a/Assets/Scripts/Player/Data/PlayerStats.cs
+++ b/Assets/Scripts/Player/Data/PlayerStats.cs
@@ -12,8 +12,10 @@ public class RobotStats
     public float MaxEnergy = 1f;
     public float CurrentEnergy = 1f;
     public float AttackEnergyCost = 1f;
+    public float EnergyRechargeRate = 1f;
     public event Action OnHealthChanged;
     public event Action OnEnergyChanged;
+    public event Action OnEnergyRechargeChanged;
     public event Action OnMoralityChanged;
     public bool AbleToAttack => CurrentEnergy >= AttackEnergyCost;
     public float Morality { get; set; } = 0f;
@@ -41,11 +43,16 @@ public class RobotStats
         Attacks = attacks ?? new List<Attack>();
     }
 
-     public void UpdateEnergy(float delta)
+    public void UpdateEnergy(float delta)
     {
         CurrentEnergy = Mathf.Clamp(CurrentEnergy + delta, 0, MaxEnergy);
         OnEnergyChanged?.Invoke();
+    }
 
+    public void UpdateEnergyRecharge(float delta)
+    {
+        EnergyRechargeRate = math.max(0f, EnergyRechargeRate + delta);
+        OnEnergyRechargeChanged?.Invoke();
     }
 
     public void UpdateHealth(float delta)


### PR DESCRIPTION
## Summary
- enable EnergyRecharge upgrade option in CubeUpgradeSO
- track energy recharge rate in RobotStats and PlayerRunStats
- record energy recharge bonuses from cube collector and add unit tests

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b289797c48324b17c6c0325f71384