### PR TITLE
Enable energy recharge upgrades

### DIFF
--- a/Assets/Editor/UnitTests/CubeCollectorTests.cs
+++ b/Assets/Editor/UnitTests/CubeCollectorTests.cs
@@ -78,5 +78,49 @@ public class CubeCollectorTests
 
         Assert.AreEqual(upgradeSO.UpgradeMaxHealthValue, runStats.MaxHealthBonus);
     }
+
+    [Test]
+    public void CollectorIncrementsEnergyRechargeRunStats()
+    {
+        var upgradeSO = ScriptableObject.CreateInstance<CubeUpgradeSO>();
+        var runStats = ScriptableObject.CreateInstance<PlayerRunStats>();
+
+        var sceneControllerGO = new GameObject("sceneController");
+        sceneControllerGO.AddComponent<SceneController>();
+
+        var rpmGO = new GameObject("runManager");
+        var rpm = rpmGO.AddComponent<RunProgressManager>();
+        typeof(RunProgressManager)
+            .GetField("runStats", BindingFlags.Instance | BindingFlags.NonPublic)
+            .SetValue(rpm, runStats);
+
+        var collectorGO = new GameObject("collector");
+        collectorGO.AddComponent<BoxCollider2D>();
+        var collector = collectorGO.AddComponent<CubeCollector>();
+        typeof(CubeCollector)
+            .GetField("upgradeStore", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(collector, upgradeSO);
+
+        var cubeGO = new GameObject("cube");
+        cubeGO.AddComponent<Rigidbody2D>();
+        cubeGO.AddComponent<TargetJoint2D>();
+        cubeGO.AddComponent<EnergyBot>();
+        cubeGO.AddComponent<HealthBot>();
+        var controller = cubeGO.AddComponent<RobotStateController>();
+        controller.Stats = new RobotStats();
+        var pickup = cubeGO.AddComponent<CubePickup>();
+        var upgrade = cubeGO.AddComponent<CubeUpgrade>();
+        var cubeCollider = cubeGO.AddComponent<BoxCollider2D>();
+
+        typeof(CubeUpgrade)
+            .GetField("upgradeType", BindingFlags.Instance | BindingFlags.NonPublic)
+            .SetValue(upgrade, CubeUpgradeType.EnergyRecharge);
+
+        var method = typeof(CubeCollector)
+            .GetMethod("OnTriggerEnter2D", BindingFlags.Instance | BindingFlags.NonPublic);
+        method.Invoke(collector, new object[] { cubeCollider });
+
+        Assert.AreEqual(upgradeSO.UpgradeEnergyRechargeValue, runStats.EnergyRechargeBonus);
+    }
 }
 

--- a/Assets/Editor/UnitTests/CubeUpgradeSOTests.cs
+++ b/Assets/Editor/UnitTests/CubeUpgradeSOTests.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+
+public class CubeUpgradeSOTests
+{
+    [Test]
+    public void ApplyUpgradeUpdatesEnergyRecharge()
+    {
+        var upgradeSO = ScriptableObject.CreateInstance<CubeUpgradeSO>();
+        typeof(CubeUpgradeSO)
+            .GetField("selectedUpgrade", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(upgradeSO, CubeUpgradeType.EnergyRecharge);
+
+        var stats = new RobotStats();
+        stats.EnergyRechargeRate = 1f;
+
+        upgradeSO.ApplyUpgrade(stats);
+
+        Assert.AreEqual(1f + upgradeSO.UpgradeEnergyRechargeValue, stats.EnergyRechargeRate);
+    }
+}

--- a/Assets/Scripts/Machines/CubeCollector.cs
+++ b/Assets/Scripts/Machines/CubeCollector.cs
@@ -45,9 +45,9 @@ public class CubeCollector : MonoBehaviour
                             runStats.MaxEnergyBonus += upgradeStore.UpgradeMaxEnergyValue;
                             break;
                         case CubeUpgradeType.EnergyRecharge:
-                            // No direct property on PlayerRunStats yet; placeholder for future logic
+                            runStats.AddEnergyRechargeBonus(upgradeStore.UpgradeEnergyRechargeValue);
                             break;
-        
+                        
                         case CubeUpgradeType.AttackDamage:
                             runStats.AttackDamageBonus += upgradeStore.UpgradeAttackDamageValue;
                             break;

--- a/Assets/Scripts/Machines/CubeUpgradeSO.cs
+++ b/Assets/Scripts/Machines/CubeUpgradeSO.cs
@@ -66,10 +66,9 @@ public class CubeUpgradeSO : ScriptableObject
                 target.MaxEnergy += upgradeMaxEnergyValue;
                 target.UpdateEnergy(upgradeMaxEnergyValue);
                 break;
-            // case CubeUpgradeType.EnergyRecharge:
-            // target.EnergyRechargeRate += upgradeEnergyRechargeValue;
-            //     target.UpdateEnergyRecharge(upgradeEnergyRechargeValue);
-            //     break;
+            case CubeUpgradeType.EnergyRecharge:
+                target.UpdateEnergyRecharge(upgradeEnergyRechargeValue);
+                break;
             case CubeUpgradeType.AttackDamage:
                 foreach (Attack attack in target.Attacks)
                     attack.Damage += upgradeAttackDamageValue;

--- a/Assets/Scripts/Player/Data/PlayerRunStats.cs
+++ b/Assets/Scripts/Player/Data/PlayerRunStats.cs
@@ -9,6 +9,10 @@ public class PlayerRunStats : ScriptableObject
     public float energyRechargeRate;
     public int attackDamage;
     public float morality;
+    public float MaxHealthBonus;
+    public float MaxEnergyBonus;
+    public float EnergyRechargeBonus;
+    public int AttackDamageBonus;
 
     private bool hasValues;
 
@@ -33,6 +37,10 @@ public class PlayerRunStats : ScriptableObject
         if (energyBot != null)
         {
             energyRechargeRate = energyBot.rechargeRate;
+        }
+        else
+        {
+            energyRechargeRate = source.EnergyRechargeRate;
         }
         if (attack != null)
         {
@@ -65,6 +73,7 @@ public class PlayerRunStats : ScriptableObject
         {
             energyBot.rechargeRate = energyRechargeRate;
         }
+        target.EnergyRechargeRate = energyRechargeRate;
         if (attack != null)
         {
             attack.Damage = attackDamage;
@@ -83,7 +92,20 @@ public class PlayerRunStats : ScriptableObject
         energyRechargeRate = 0f;
         attackDamage = 0;
         morality = 0f;
+        MaxHealthBonus = 0f;
+        MaxEnergyBonus = 0f;
+        EnergyRechargeBonus = 0f;
+        AttackDamageBonus = 0;
 
         hasValues = false;
+    }
+
+    /// <summary>
+    /// Adds to the energy recharge bonus accumulated during the run.
+    /// </summary>
+    /// <param name="value">Bonus amount to add.</param>
+    public void AddEnergyRechargeBonus(float value)
+    {
+        EnergyRechargeBonus += value;
     }
 }

--- a/Assets/Scripts/Player/Data/PlayerStats.cs
+++ b/Assets/Scripts/Player/Data/PlayerStats.cs
@@ -12,8 +12,10 @@ public class RobotStats
     public float MaxEnergy = 1f;
     public float CurrentEnergy = 1f;
     public float AttackEnergyCost = 1f;
+    public float EnergyRechargeRate = 0f;
     public event Action OnHealthChanged;
     public event Action OnEnergyChanged;
+    public event Action OnEnergyRechargeChanged;
     public event Action OnMoralityChanged;
     public bool AbleToAttack => CurrentEnergy >= AttackEnergyCost;
     public float Morality { get; set; } = 0f;
@@ -46,6 +48,16 @@ public class RobotStats
         CurrentEnergy = Mathf.Clamp(CurrentEnergy + delta, 0, MaxEnergy);
         OnEnergyChanged?.Invoke();
 
+    }
+
+    /// <summary>
+    /// Adjusts the energy recharge rate by the provided amount.
+    /// </summary>
+    /// <param name="delta">Amount to change recharge rate.</param>
+    public void UpdateEnergyRecharge(float delta)
+    {
+        EnergyRechargeRate = math.max(0f, EnergyRechargeRate + delta);
+        OnEnergyRechargeChanged?.Invoke();
     }
 
     public void UpdateHealth(float delta)


### PR DESCRIPTION
## Summary
- Support CubeUpgradeType.EnergyRecharge upgrades and update robot recharge rates
- Track energy recharge bonuses during runs
- Add unit tests for recharge upgrades

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b27b1b0508324998a2680b5025e12