### PR TITLE
Capture and apply max stats

### DIFF
--- a/Assets/Scripts/Machines/CubeCollector.cs
+++ b/Assets/Scripts/Machines/CubeCollector.cs
@@ -30,7 +30,8 @@ public class CubeCollector : MonoBehaviour
         {
             upgradeStore.Store(cube.UpgradeType);
 
-            RobotStats playerStats = other.GetComponentInParent<RobotStateController>()?.Stats;
+            RobotStateController controller = other.GetComponentInParent<RobotStateController>();
+            RobotStats playerStats = controller?.Stats;
             PlayerRunStats runStats = RunProgressManager.Instance?.RunStats;
             if (playerStats != null)
             {
@@ -47,7 +48,7 @@ public class CubeCollector : MonoBehaviour
                         case CubeUpgradeType.EnergyRecharge:
                             // No direct property on PlayerRunStats yet; placeholder for future logic
                             break;
-        
+
                         case CubeUpgradeType.AttackDamage:
                             runStats.AttackDamageBonus += upgradeStore.UpgradeAttackDamageValue;
                             break;
@@ -55,7 +56,9 @@ public class CubeCollector : MonoBehaviour
                 }
 
                 upgradeStore.ApplyUpgrade(playerStats);
-                runStats?.Capture(playerStats);
+                EnergyBot energyBot = controller != null ? controller.GetComponent<EnergyBot>() : null;
+                Attack attack = playerStats.Attacks.Count > 0 ? playerStats.Attacks[0] : null;
+                runStats?.Capture(playerStats, energyBot, attack);
             }
 
             Destroy(pickup.gameObject);

--- a/Assets/Scripts/Player/Data/PlayerRunStats.cs
+++ b/Assets/Scripts/Player/Data/PlayerRunStats.cs
@@ -1,14 +1,19 @@
 using UnityEngine;
+using UnityEngine.Serialization;
 
 [CreateAssetMenu(fileName = "PlayerRunStats", menuName = "Player/RunStats")]
 public class PlayerRunStats : ScriptableObject
 {
-    public float currentHealth;
-    public float maxHealth;
-    public float maxEnergy;
-    public float energyRechargeRate;
-    public int attackDamage;
-    public float morality;
+    [FormerlySerializedAs("currentHealth")] public float CurrentHealth;
+    [FormerlySerializedAs("maxHealth")] public float MaxHealth;
+    [FormerlySerializedAs("maxEnergy")] public float MaxEnergy;
+    [FormerlySerializedAs("energyRechargeRate")] public float EnergyRechargeRate;
+    [FormerlySerializedAs("attackDamage")] public int AttackDamage;
+    [FormerlySerializedAs("morality")] public float Morality;
+
+    public float MaxHealthBonus;
+    public float MaxEnergyBonus;
+    public int AttackDamageBonus;
 
     private bool hasValues;
 
@@ -26,17 +31,17 @@ public class PlayerRunStats : ScriptableObject
         {
             return;
         }
-        currentHealth = Mathf.Clamp(source.CurrentHealth, 0f, source.MaxHealth);
-        maxHealth = source.MaxHealth;
-        maxEnergy = source.MaxEnergy;
-        morality = source.Morality;
+        CurrentHealth = Mathf.Clamp(source.CurrentHealth, 0f, source.MaxHealth);
+        MaxHealth = source.MaxHealth;
+        MaxEnergy = source.MaxEnergy;
+        Morality = source.Morality;
         if (energyBot != null)
         {
-            energyRechargeRate = energyBot.rechargeRate;
+            EnergyRechargeRate = energyBot.rechargeRate;
         }
         if (attack != null)
         {
-            attackDamage = attack.Damage;
+            AttackDamage = attack.Damage;
         }
 
         hasValues = true;
@@ -56,18 +61,18 @@ public class PlayerRunStats : ScriptableObject
             return;
         }
 
-        target.MaxHealth = maxHealth;
-        target.MaxEnergy = maxEnergy;
-        float healthTarget = Mathf.Clamp(currentHealth, 0f, target.MaxHealth);
+        target.MaxHealth = MaxHealth;
+        target.MaxEnergy = MaxEnergy;
+        float healthTarget = Mathf.Clamp(CurrentHealth, 0f, target.MaxHealth);
         target.UpdateHealth(healthTarget - target.CurrentHealth);
-        target.UpdateMorality(morality - target.Morality);
+        target.UpdateMorality(Morality - target.Morality);
         if (energyBot != null)
         {
-            energyBot.rechargeRate = energyRechargeRate;
+            energyBot.rechargeRate = EnergyRechargeRate;
         }
         if (attack != null)
         {
-            attack.Damage = attackDamage;
+            attack.Damage = AttackDamage;
         }
 
     }
@@ -77,12 +82,15 @@ public class PlayerRunStats : ScriptableObject
     /// </summary>
     public void Reset()
     {
-        currentHealth = 0f;
-        maxHealth = 0f;
-        maxEnergy = 0f;
-        energyRechargeRate = 0f;
-        attackDamage = 0;
-        morality = 0f;
+        CurrentHealth = 0f;
+        MaxHealth = 0f;
+        MaxEnergy = 0f;
+        EnergyRechargeRate = 0f;
+        AttackDamage = 0;
+        Morality = 0f;
+        MaxHealthBonus = 0f;
+        MaxEnergyBonus = 0f;
+        AttackDamageBonus = 0;
 
         hasValues = false;
     }


### PR DESCRIPTION
## Summary
- Track max health and max energy in PlayerRunStats and reset/restore them when capturing/applying run data
- Ensure CubeCollector passes energy and attack info to PlayerRunStats when upgrades are collected

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b288cec10832496caa38a6353570a