### PR TITLE
Guard attack gating based on player morality and alarm

### DIFF
--- a/Assets/Resources/Prefabs/Robots/SecurityGuard.prefab
+++ b/Assets/Resources/Prefabs/Robots/SecurityGuard.prefab
@@ -4697,6 +4697,7 @@ MonoBehaviour:
   leftArmHitbox: {fileID: 3250705526059779659}
   rightArmHitbox: {fileID: 1545105698887083221}
   memory: {fileID: 4652158946510775221}
+  alarmStatus: {fileID: 11400000, guid: ce6d93aba8639b74f8e3f0b7ef4b3919, type: 2}
 --- !u!114 &4282379396995134653
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyPunchAttack.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyPunchAttack.cs
@@ -36,16 +36,28 @@ public class EnemyPunchAttack : MonoBehaviour
     private RobotStateController robotBehaviour;
 
     [SerializeField] private RobotMemory memory;
+    [SerializeField] private FactoryAlarmStatus alarmStatus;
+    private RobotStats playerStats;
     private bool playerInAttackZone = false;
     private void Awake()
     {
         robotBehaviour = GetComponent<RobotStateController>();
+        if (alarmStatus == null)
+        {
+            alarmStatus = FindObjectOfType<FactoryManager>()?.factoryAlarmStatus;
+        }
     }
     private void Start()
     {
         if (targetToFollow != null)
         {
             targetToFollow.OnPlayerDetectInAttackZoneChanged += HandlePlayerInAttackZoneChange;
+        }
+        GameObject player = GameObject.FindGameObjectWithTag("Player");
+        if (player != null)
+        {
+            RobotStateController controller = player.GetComponent<RobotStateController>();
+            playerStats = controller?.Stats;
         }
     }
 
@@ -56,6 +68,14 @@ public class EnemyPunchAttack : MonoBehaviour
 
     private void Update()
     {
+        if (playerStats != null &&
+            playerStats.Morality > 5f &&
+            alarmStatus != null &&
+            alarmStatus.CurrentAlarmState != AlarmState.Wanted)
+        {
+            return; // Guards stand down
+        }
+
         if (!targetToFollow || !punchTarget || isPunching) return;
 
         if (!playerInAttackZone || targetToFollow.PlayerBodyReferencePosition == Vector3.zero) return;


### PR DESCRIPTION
## Summary
- Cache player stats and shared alarm status in EnemyPunchAttack
- Prevent guards from punching when player morality is high and alarm not at Wanted
- Link SecurityGuard prefab to FactoryAlarmStatus asset

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b3afa2d208324bc5ee35441a8b317