### PR TITLE
Clear joint lists in JointBreaker Awake to avoid duplicates

### DIFF
--- a/Assets/Scripts/Robots/JointBreaker.cs
+++ b/Assets/Scripts/Robots/JointBreaker.cs
@@ -30,6 +30,10 @@ public class JointBreaker : MonoBehaviour
 
     private void Awake()
     {
+        hingeJoints.Clear();
+        fixedJoints.Clear();
+        ikSolvers.Clear();
+
         hingeJoints.AddRange(GetComponentsInChildren<HingeJoint2D>());
         fixedJoints.AddRange(GetComponentsInChildren<FixedJoint2D>());
         ikSolvers.AddRange(GetComponentsInChildren<Hinge2DIkSolver>());


### PR DESCRIPTION
## Summary
- Prevent duplicate joints by clearing lists in `JointBreaker.Awake`

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found: unity)*

------
https://chatgpt.com/codex/tasks/task_e_689b476f12f083249d47dd3d272d75c1