### PR TITLE
Add joint null checks to CubePickup

### DIFF
--- a/Assets/Scripts/Player/GrabSystem/CubePickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/CubePickup.cs
@@ -26,18 +26,20 @@ public class CubePickup : MonoBehaviour, IGrabbable
     {
         rb = GetComponent<Rigidbody2D>();
         joint = GetComponent<TargetJoint2D>();
-
-        joint.enabled = false;
-        joint.autoConfigureTarget = false;
-        joint.target = rb.position;
-        joint.frequency = frequency;
-        joint.dampingRatio = dampingRatio;
-        joint.maxForce = maxForce;
+        if (joint != null)
+        {
+            joint.enabled = false;
+            joint.autoConfigureTarget = false;
+            joint.target = rb.position;
+            joint.frequency = frequency;
+            joint.dampingRatio = dampingRatio;
+            joint.maxForce = maxForce;
+        }
     }
 
     private void FixedUpdate()
     {
-        if (joint.enabled && followTarget != null)
+        if (joint != null && joint.enabled && followTarget != null)
             joint.target = followTarget.position;
     }
 
@@ -91,12 +93,18 @@ public class CubePickup : MonoBehaviour, IGrabbable
 
     public void OnAttract(Vector2 attractPoint)
     {
+        if (joint == null)
+            return;
+
         if (attached && joint.enabled && followTarget == null)
             joint.target = attractPoint;
     }
 
     public void OnRelease(Vector2 throwForce)
     {
+        if (joint == null)
+            return;
+
         attached = false;
         joint.enabled = false;
         followTarget = null;


### PR DESCRIPTION
## Summary
- guard `TargetJoint2D` usage with null checks to prevent NREs
- early-return from attract/release when joint missing

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b478ae4d4832495bb02e77ec68173