### PR TITLE
Add null guards for BatteryPickup joint

### DIFF
--- a/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
@@ -26,18 +26,20 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
     {
         rb = GetComponent<Rigidbody2D>();
         joint = GetComponent<TargetJoint2D>();
-
-        joint.enabled = false;
-        joint.autoConfigureTarget = false;
-        joint.target = rb.position;
-        joint.frequency = frequency;
-        joint.dampingRatio = dampingRatio;
-        joint.maxForce = maxForce;
+        if (joint != null)
+        {
+            joint.enabled = false;
+            joint.autoConfigureTarget = false;
+            joint.target = rb.position;
+            joint.frequency = frequency;
+            joint.dampingRatio = dampingRatio;
+            joint.maxForce = maxForce;
+        }
     }
 
     private void FixedUpdate()
     {
-        if (joint.enabled && followTarget != null)
+        if (joint != null && joint.enabled && followTarget != null)
             joint.target = followTarget.position;
     }
 
@@ -120,6 +122,9 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
 
     public void OnAttract(Vector2 attractPoint)
     {
+        if (joint == null)
+            return;
+
         if (attached && joint.enabled && followTarget == null)
             joint.target = attractPoint;
     }
@@ -127,7 +132,8 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
     public void OnRelease(Vector2 throwForce)
     {
         attached = false;
-        joint.enabled = false;
+        if (joint != null)
+            joint.enabled = false;
         followTarget = null;
         rb.simulated = true;
 


### PR DESCRIPTION
## Summary
- handle missing TargetJoint2D in BatteryPickup
- add checks so attracting and releasing batteries won't fail without a joint

## Testing
- `bash setup_env.sh` *(fails: Package 'libasound2' has no installation candidate)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b4a4039088324865a408525798971