### PR TITLE
Add joint null checks in CubePickup

### DIFF
--- a/Assets/Scripts/Player/GrabSystem/CubePickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/CubePickup.cs
@@ -96,7 +96,7 @@ public class CubePickup : MonoBehaviour, IGrabbable
         if (joint == null)
             return;
 
-        if (attached && joint.enabled && followTarget == null)
+        if (attached && joint != null && joint.enabled && followTarget == null)
             joint.target = attractPoint;
     }
 
@@ -106,7 +106,8 @@ public class CubePickup : MonoBehaviour, IGrabbable
             return;
 
         attached = false;
-        joint.enabled = false;
+        if (joint != null)
+            joint.enabled = false;
         followTarget = null;
 
         OnReleased?.Invoke(this);


### PR DESCRIPTION
## Summary
- Safeguard CubePickup joint operations with explicit null checks
- Prevent attract and release actions when target joint is missing

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b57ef3a00832495d7009893e8341b