### PR TITLE
Clear joint lists to avoid duplicate entries

### DIFF
--- a/Assets/Scripts/Robots/JointBreaker.cs
+++ b/Assets/Scripts/Robots/JointBreaker.cs
@@ -30,6 +30,8 @@ public class JointBreaker : MonoBehaviour
 
     private void Awake()
     {
+        // Ensure lists start empty to avoid duplicate entries when the
+        // component is reused or deserialized with existing items.
         hingeJoints.Clear();
         fixedJoints.Clear();
         ikSolvers.Clear();


### PR DESCRIPTION
## Summary
- Document why `JointBreaker` clears hinge, fixed and IK solver lists in `Awake`

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b6720c4208324bf0ac901eac3209c