### PR TITLE
Guard joint access in CubePickup

### DIFF
--- a/Assets/Scripts/Player/GrabSystem/CubePickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/CubePickup.cs
@@ -39,8 +39,10 @@ public class CubePickup : MonoBehaviour, IGrabbable
 
     private void FixedUpdate()
     {
-        if (joint != null && joint.enabled && followTarget != null)
-            joint.target = followTarget.position;
+        if (joint == null || !joint.enabled || followTarget == null)
+            return;
+
+        joint.target = followTarget.position;
     }
 
     public void SetFollowTarget(Transform target)
@@ -96,7 +98,7 @@ public class CubePickup : MonoBehaviour, IGrabbable
         if (joint == null)
             return;
 
-        if (attached && joint != null && joint.enabled && followTarget == null)
+        if (attached && joint.enabled && followTarget == null)
             joint.target = attractPoint;
     }
 
@@ -106,8 +108,7 @@ public class CubePickup : MonoBehaviour, IGrabbable
             return;
 
         attached = false;
-        if (joint != null)
-            joint.enabled = false;
+        joint.enabled = false;
         followTarget = null;
 
         OnReleased?.Invoke(this);


### PR DESCRIPTION
## Summary
- Avoid accessing TargetJoint2D when missing by returning early in `FixedUpdate`, `OnAttract` and `OnRelease`
- Disable cube joint safely only when present

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b6c17104083249f9ae0c312921cff