### PR TITLE
Add null joint guard clauses for SecurityBadgePickup

### DIFF
--- a/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
@@ -44,10 +44,10 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
 
     void FixedUpdate()
     {
-        if (joint != null && joint.enabled && followTarget != null)
-        {
-            joint.target = followTarget.position;
-        }
+        if (joint == null || !joint.enabled || followTarget == null)
+            return;
+
+        joint.target = followTarget.position;
     }
 
     public void SetFollowTarget(Transform target)
@@ -129,11 +129,10 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
 
     public void OnAttract(Vector2 attractPoint)
     {
-        if (joint == null)
+        if (joint == null || !attached || !joint.enabled || followTarget != null)
             return;
 
-        if (attached && joint.enabled && followTarget == null)
-            joint.target = attractPoint;
+        joint.target = attractPoint;
     }
 
     public void OnRelease(Vector2 throwForce)


### PR DESCRIPTION
## Summary
- Guard SecurityBadgePickup's joint usage in `FixedUpdate`
- Add null checks to `OnAttract` so it matches other pickup scripts

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b6f4a487c832490b122ccca483a1f