### PR TITLE
Handle missing Rigidbody2D on release

### DIFF
--- a/Assets/Scripts/Inventory/Inventory.cs
+++ b/Assets/Scripts/Inventory/Inventory.cs
@@ -54,9 +54,13 @@ public class Inventory : MonoBehaviour
     /// </summary>
     public void DropItem(PickupType type)
     {
-        if (items.TryGetValue(type, out var item) && item != null)
+        if (items.TryGetValue(type, out var item))
         {
-            item.OnRelease(Vector2.zero);
+            var unityObject = item as Object;
+            if (unityObject != null)
+            {
+                item.OnRelease(Vector2.zero);
+            }
         }
         items.Remove(type);
     }
@@ -69,7 +73,11 @@ public class Inventory : MonoBehaviour
         var itemsToDrop = new List<IGrabbable>(items.Values);
         foreach (var item in itemsToDrop)
         {
-            item?.OnRelease(Vector2.zero);
+            var unityObject = item as Object;
+            if (unityObject != null)
+            {
+                item.OnRelease(Vector2.zero);
+            }
         }
         items.Clear();
     }

--- a/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
@@ -137,7 +137,15 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
             joint.enabled = false;
 
         followTarget = null;
-        rb.simulated = true;
+
+        if (rb != null)
+        {
+            rb.simulated = true;
+        }
+        else
+        {
+            Debug.LogWarning($"{nameof(BatteryPickup)} on {name} is missing a {nameof(Rigidbody2D)} component.");
+        }
 
         if (ownerInventory != null)
         {


### PR DESCRIPTION
## Summary
- Prevent crash when releasing battery without Rigidbody2D by null-checking the component
- Avoid calling OnRelease on destroyed inventory items

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689baedf998083248fd5823f6dc92e53