### PR TITLE
Handle hand clearing before inventory drops

### DIFF
--- a/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
+++ b/Assets/Scripts/Game/LevelEndVictoryTrigger.cs
@@ -45,6 +45,7 @@ public class LevelEndVictoryTrigger : MonoBehaviour
             {
                 RobotStateController controller = collision.GetComponentInParent<RobotStateController>();
                 GrabSystem grabSystem = collision.GetComponentInParent<GrabSystem>();
+                Inventory inventory = collision.GetComponentInParent<Inventory>();
 
                 if (grabSystem == null)
                 {
@@ -53,7 +54,6 @@ public class LevelEndVictoryTrigger : MonoBehaviour
                 else
                 {
                     grabSystem.ClearHands();
-                    var inventory = collision.GetComponentInParent<Inventory>();
                     inventory?.DropAll();
                 }
 

--- a/Assets/Scripts/Player/GrabSystem/GrabSystem.cs
+++ b/Assets/Scripts/Player/GrabSystem/GrabSystem.cs
@@ -89,28 +89,27 @@ public class GrabSystem : MonoBehaviour
         {
             UnityEngine.Object obj = leftHeld as UnityEngine.Object;
             if (obj != null)
+            {
                 Release(leftHand, ref leftHeld, 0f);
+            }
             else
+            {
                 leftHeld = null;
+            }
         }
 
         if (rightHeld != null)
         {
             UnityEngine.Object obj = rightHeld as UnityEngine.Object;
             if (obj != null)
+            {
                 Release(rightHand, ref rightHeld, 0f);
+            }
             else
+            {
                 rightHeld = null;
+            }
         }
-
-        var inventory = GetComponent<Inventory>();
-        if (inventory != null)
-        {
-            inventory.DropAll();
-        }
-
-        leftHeld = null;
-        rightHeld = null;
     }
 
     private void TryGrab(GrabHandAttractor hand, ref IGrabbable held)


### PR DESCRIPTION
## Summary
- Simplify `GrabSystem.ClearHands` to release each held item and stop dropping inventory
- Ensure `LevelEndVictoryTrigger` clears hands before inventory items are dropped

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found: unity)*

------
https://chatgpt.com/codex/tasks/task_e_689bafcf38648324a70e95589a579e93