### PR TITLE
Fix loop attribute for single-segment paths

### DIFF
--- a/Assets/Shapes2D/Shaders/Path.cginc
+++ b/Assets/Shapes2D/Shaders/Path.cginc
@@ -124,7 +124,11 @@ float2 distance_to_path(float2 pos) {
     // you can't do variable-length loops in webgl (or es2 technically I think), 
     // hence the constant...so we have to iterate through MAX_SEGMENTS rather than 
     // _NumSegments which is the number of vertices actually in our poly
+    #if MAX_SEGMENTS > 1
     UNITY_LOOP
+    #else
+    UNITY_UNROLL
+    #endif
     for (int i = 0; i < MAX_SEGMENTS; i++) {
         // loop_over is 1 when we're past the number of sides in the poly
         float loop_over = when_ge(i, _NumSegments);


### PR DESCRIPTION
## Summary
- Avoid [loop] attribute when path has a single segment by switching to `UNITY_UNROLL`

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c2d1028cc8324bccdbc01735d346d