### PR TITLE
Fix TextMeshPro compilation errors

### DIFF
--- a/Assets/Scripts/Game.asmdef
+++ b/Assets/Scripts/Game.asmdef
@@ -7,7 +7,8 @@
         "Unity.Mathematics",
         "Unity.Cinemachine",
         "Unity.InputSystem",
-        "UpdateManager"
+        "UpdateManager",
+        "Unity.TextMeshPro"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
## Summary
- reference Unity.TextMeshPro in Game assembly definition to resolve TMP namespace

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(command failed: command not found: unity)*

------
https://chatgpt.com/codex/tasks/task_e_689c360c5a7883248dba61d361ff171a