### PR TITLE
Center minimap using actual renderer bounds

### DIFF
--- a/Assets/Scripts/Navigation/MapManager.cs
+++ b/Assets/Scripts/Navigation/MapManager.cs
@@ -156,6 +156,42 @@ public class MapManager : MonoBehaviour
         gridManager.AssignRoomProperties(roomInstances, cellDataGrid);
     }
 
+    /// <summary>
+    /// Returns the world-space bounds of all renderers under this map.
+    /// </summary>
+    /// <param name="rootOverride">Optional root transform to search under.</param>
+    /// <param name="layerMask">Layer mask for filtering included renderers.</param>
+    /// <returns>Bounds encompassing all included renderers.</returns>
+    public Bounds GetGridWorldBounds(Transform rootOverride = null, int layerMask = ~0)
+    {
+        var root = rootOverride != null ? rootOverride : transform;
+        var renderers = root.GetComponentsInChildren<Renderer>(includeInactive: false);
+
+        bool hasBounds = false;
+        Bounds bounds = default;
+
+        foreach (var r in renderers)
+        {
+            if (((1 << r.gameObject.layer) & layerMask) == 0)
+                continue;
+
+            if (!hasBounds)
+            {
+                bounds = r.bounds;
+                hasBounds = true;
+            }
+            else
+            {
+                bounds.Encapsulate(r.bounds);
+            }
+        }
+
+        if (!hasBounds)
+            bounds = new Bounds(root.position, Vector3.one);
+
+        return bounds;
+    }
+
     // ============================================================================
     //  HELPERS
     // ============================================================================

--- a/Assets/Scripts/UI/GameUIViewModel.cs
+++ b/Assets/Scripts/UI/GameUIViewModel.cs
@@ -217,9 +217,7 @@ public class GameUIViewModel : MonoBehaviour
     public void SetMiniMapTexture(MapManager mapManagerInstance)
     {
         miniMapPreviewInstance = Instantiate(miniMapPreviewPrefab);
-        float worldWidth = config.gridWidth * mapManagerInstance.cellWidth;
-        float worldHeight = config.gridHeight * mapManagerInstance.cellHeight;
-        Vector3 origin = mapManagerInstance.transform.position;
+        Bounds bounds = mapManagerInstance.GetGridWorldBounds();
 
         var cam = miniMapPreviewInstance.GetComponentInChildren<Camera>();
         if (cam != null)
@@ -227,16 +225,21 @@ public class GameUIViewModel : MonoBehaviour
             cam.orthographic = true;
             float aspect = (float)miniMapRT.width / miniMapRT.height;
 
-            float halfH = worldHeight * 0.5f;
-            float halfW_as_H = (worldWidth * 0.5f) / aspect;
+            float halfH = bounds.size.y * 0.5f;
+            float halfWAsH = (bounds.size.x * 0.5f) / aspect;
             float padding = 0.05f;
-            cam.orthographicSize = Mathf.Max(halfH, halfW_as_H) * (1f + padding);
+            cam.orthographicSize = Mathf.Max(halfH, halfWAsH) * (1f + padding);
 
-            Vector3 center = origin + new Vector3(worldWidth * 0.5f, worldHeight * 0.5f, 0f);
-            cam.transform.position = new Vector3(center.x, center.y, -10f);
+            Vector3 pos = bounds.center;
+            pos.z = -10f;
+            cam.transform.position = pos;
             cam.transform.rotation = Quaternion.identity;
 
             cam.targetTexture = miniMapRT;
+
+            var debug = cam.GetComponent<MiniMapDebugGizmos>();
+            if (debug != null)
+                debug.gridBounds = bounds;
         }
         StartCoroutine(CaptureRTToUI());
     }

--- a/Assets/Scripts/UI/MiniMapDebugGizmos.cs
+++ b/Assets/Scripts/UI/MiniMapDebugGizmos.cs
@@ -1,0 +1,33 @@
+#if UNITY_EDITOR
+using UnityEngine;
+
+[ExecuteAlways]
+public class MiniMapDebugGizmos : MonoBehaviour
+{
+    public Bounds gridBounds;
+    public Camera cam;
+    public float aspect;
+
+    void OnDrawGizmos()
+    {
+        if (cam == null) cam = GetComponent<Camera>();
+        if (cam == null || !cam.orthographic) return;
+
+        aspect = (cam.targetTexture != null)
+            ? (float)cam.targetTexture.width / cam.targetTexture.height
+            : (float)Screen.width / Screen.height;
+
+        float halfH = cam.orthographicSize;
+        float halfW = halfH * aspect;
+
+        Gizmos.color = Color.yellow;
+        var c = cam.transform.position;
+        var min = new Vector3(c.x - halfW, c.y - halfH, 0);
+        var max = new Vector3(c.x + halfW, c.y + halfH, 0);
+        Gizmos.DrawWireCube((min + max) * 0.5f, max - min);
+
+        Gizmos.color = Color.magenta;
+        Gizmos.DrawWireCube(gridBounds.center, gridBounds.size);
+    }
+}
+#endif

--- a/Assets/Scripts/UI/RunSetupManager.cs
+++ b/Assets/Scripts/UI/RunSetupManager.cs
@@ -342,9 +342,7 @@ public class RunSetupManager : MonoBehaviour
         {
             factoryManagerInstance.Initialize(mapManagerInstance, waypointServiceInstance, victorySetup, enemiesSpawnerInstance);
         }
-        float worldWidth = config.gridWidth * mapManagerInstance.cellWidth;
-        float worldHeight = config.gridHeight * mapManagerInstance.cellHeight;
-        Vector3 origin = mapManagerInstance.transform.position;
+        Bounds bounds = mapManagerInstance.GetGridWorldBounds();
 
         // 2) Frame the camera
         var cam = miniMapPreviewInstance.GetComponentInChildren<Camera>();
@@ -352,16 +350,21 @@ public class RunSetupManager : MonoBehaviour
         {
             cam.orthographic = true;
             float aspect = (float)miniMapRT.width / miniMapRT.height;
-            float halfH = worldHeight * 0.5f;
-            float halfW_as_H = (worldWidth * 0.5f) / aspect;
+            float halfH = bounds.size.y * 0.5f;
+            float halfWAsH = (bounds.size.x * 0.5f) / aspect;
             float padding = 0.05f;
-            cam.orthographicSize = Mathf.Max(halfH, halfW_as_H) * (1f + padding);
+            cam.orthographicSize = Mathf.Max(halfH, halfWAsH) * (1f + padding);
 
-            Vector3 center = origin + new Vector3(worldWidth * 0.5f, worldHeight * 0.5f, 0f);
-            cam.transform.position = new Vector3(center.x, center.y, -10f);
+            Vector3 pos = bounds.center;
+            pos.z = -10f;
+            cam.transform.position = pos;
             cam.transform.rotation = Quaternion.identity;
 
             // cam.targetTexture = miniMapRT;
+
+            var debug = cam.GetComponent<MiniMapDebugGizmos>();
+            if (debug != null)
+                debug.gridBounds = bounds;
         }
 
         // 3) Capture to Texture2D via coroutine


### PR DESCRIPTION
## Summary
- compute world-space bounds from renderers to avoid minimap drift
- fit minimap camera to these bounds
- add optional gizmo script to visualize camera and grid

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c3a0bdba88324afccfb8e18bb69da