### PR TITLE
refactor: separate sandbox config from run configs

### DIFF
--- a/Assets/Resources/Prefabs/Setup/RunProgressManager.prefab
+++ b/Assets/Resources/Prefabs/Setup/RunProgressManager.prefab
@@ -45,10 +45,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mapConfigs:
-  - {fileID: 11400000, guid: 7389573697e35074e8cf50f45fae4d43, type: 2}
   - {fileID: 11400000, guid: 154e1c44ead135e45a902eca0495e1ec, type: 2}
   - {fileID: 11400000, guid: 220ec21f1b0240946830eebd3a0ff311, type: 2}
   - {fileID: 11400000, guid: a39337ca76c62d44b8d72f119f51a4e8, type: 2}
+  sandboxConfig: {fileID: 11400000, guid: 7389573697e35074e8cf50f45fae4d43, type: 2}
   runNormalSceneName: MapGeneration
   runSandboxSceneName: SetupSandbox
   sceneControllerPrefab: {fileID: 3662908670334199631, guid: 3bf2939990ae2ab4f91281497ab365f7, type: 3}

--- a/Assets/Scripts/Game/RunProgressManager.cs
+++ b/Assets/Scripts/Game/RunProgressManager.cs
@@ -7,6 +7,7 @@ public class RunProgressManager : MonoBehaviour
     public static RunProgressManager Instance { get; private set; }
 
     [SerializeField] private List<RunMapConfigSO> mapConfigs = new List<RunMapConfigSO>();
+    [SerializeField] private RunMapConfigSO sandboxConfig;
     [SerializeField] private string runNormalSceneName = "MapGeneration";
     [SerializeField] private string runSandboxSceneName = "SetupSandbox";
     [SerializeField] private SceneController sceneControllerPrefab;
@@ -29,15 +30,25 @@ public class RunProgressManager : MonoBehaviour
     {
         get
         {
-            if (mapConfigs == null || mapConfigs.Count == 0) return null;
+            if (currentLevelIndex == 0)
+            {
+                return sandboxConfig;
+            }
+
+            if (mapConfigs == null || mapConfigs.Count == 0)
+            {
+                return null;
+            }
+
+            int index = currentLevelIndex - 1;
             RunMapConfigSO cfg;
-            if (currentLevelIndex >= mapConfigs.Count)
+            if (index >= mapConfigs.Count)
             {
                 cfg = CreateDynamicConfig(currentLevelIndex);
             }
             else
             {
-                cfg = mapConfigs[currentLevelIndex];
+                cfg = mapConfigs[index];
             }
             return cfg;
         }
@@ -59,6 +70,7 @@ public class RunProgressManager : MonoBehaviour
     }
     public void LoadSandBox()
     {
+        // Index 0 is reserved for the sandbox configuration
         currentLevelIndex = 0;
         playerTemplate.ResetStats();
         runStats.Reset();


### PR DESCRIPTION
## Summary
- add dedicated sandboxConfig field
- reserve level index 0 for sandbox and adjust map config access
- update RunProgressManager prefab to assign sandboxConfig

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c3c75ff208324ad3d3c65f63b5af7