### PR TITLE
Refresh minimap via security camera updates

### DIFF
--- a/Assets/Scripts/Map/SecurityCamera.cs
+++ b/Assets/Scripts/Map/SecurityCamera.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -21,7 +22,11 @@ public class SecurityCamera : MonoBehaviour
 
     [Header("Room & Player References")]
     public RoomManager roomManager;
-
+    [Header("Minimap Update")]
+    [SerializeField] private float minimapRefreshInterval = 2f;
+    private Coroutine minimapRoutine;
+    private GameUIViewModel minimapView;
+    private Vector3 lastPlayerPosition;
 
     private List<IRobotMemory> enemiesInZone = new List<IRobotMemory>();
     private HashSet<IRobotMemory> alarmedMemories = new HashSet<IRobotMemory>();
@@ -46,6 +51,8 @@ public class SecurityCamera : MonoBehaviour
         {
             detectAggresionZone.onEnter.AddListener(OnSecondaryZoneEnter);
         }
+
+        minimapView = FindObjectOfType<GameUIViewModel>();
     }
 
     private void Update()
@@ -101,6 +108,10 @@ public class SecurityCamera : MonoBehaviour
 
             Vector2 playerPos = player.transform.position;
             roomManager.waypointService.UpdateClosestWaypointToPlayer(playerPos);
+            lastPlayerPosition = targetToFollow.position;
+            if (minimapRoutine != null)
+                StopCoroutine(minimapRoutine);
+            minimapRoutine = StartCoroutine(RefreshMinimapWhilePlayerMoving());
         }
         else
         {
@@ -115,6 +126,23 @@ public class SecurityCamera : MonoBehaviour
 
         Vector2 playerPos = player.transform.position;
         roomManager.waypointService.UpdateClosestWaypointToPlayer(playerPos);
+        if (minimapRoutine != null)
+            StopCoroutine(minimapRoutine);
+    }
+
+    private IEnumerator RefreshMinimapWhilePlayerMoving()
+    {
+        while (isFollowing && targetToFollow != null)
+        {
+            Vector3 currentPos = targetToFollow.position;
+            if ((currentPos - lastPlayerPosition).sqrMagnitude > 0.01f)
+            {
+                minimapView?.RefreshMinimapTexture();
+                UpdateWantedPlayerPosition();
+                lastPlayerPosition = currentPos;
+            }
+            yield return new WaitForSeconds(minimapRefreshInterval);
+        }
     }
 
     private void OnSecondaryZoneEnter(Collider2D enemyCollider)
@@ -175,6 +203,8 @@ public class SecurityCamera : MonoBehaviour
 
     private void OnDestroy()
     {
+        if (minimapRoutine != null)
+            StopCoroutine(minimapRoutine);
         if (playerFollowTriggerZone != null)
         {
             playerFollowTriggerZone.onEnter.RemoveListener(OnPlayerEnterZone);

--- a/Assets/Scripts/UI/GameUIViewModel.cs
+++ b/Assets/Scripts/UI/GameUIViewModel.cs
@@ -1,6 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -24,7 +22,6 @@ public class GameUIViewModel : MonoBehaviour
     private Button resumeButton;
     private Button restartButton;
     private Button mainMenuButton;
-    private readonly List<RoomManager> subscribedRooms = new();
 
     private void Awake()
     {
@@ -111,13 +108,6 @@ public class GameUIViewModel : MonoBehaviour
             int index = RunProgressManager.Instance.CurrentLevelIndex;
             var realLevel = index - 1;
             levelPrefix = index == 1 ? "Level Tutorial. " : $"Level {realLevel}: ";
-
-            var rooms = FindObjectsByType<RoomManager>(FindObjectsSortMode.None);
-            foreach (var room in rooms)
-            {
-                room.PlayerEntered += RefreshMinimapWhenPlayerEnteredRoom;
-                subscribedRooms.Add(room);
-            }
         }
 
         var msg = new GameMessage(levelPrefix + startMessage.Text, startMessage.Speaker);
@@ -250,12 +240,6 @@ public class GameUIViewModel : MonoBehaviour
         Debug.Log("Minimap texture refreshed.");
     }
 
-    private void RefreshMinimapWhenPlayerEnteredRoom(RoomManager room)
-    {
-        RefreshMinimapTexture();
-    }
-
-
     private void OnDestroy()
     {
         if (robotBehaviour != null)
@@ -264,14 +248,6 @@ public class GameUIViewModel : MonoBehaviour
             if (robotBehaviour.Stats != null)
             {
                 robotBehaviour.Stats.OnMoralityChanged -= UpdateMoralityLabel;
-            }
-        }
-
-        foreach (var room in subscribedRooms)
-        {
-            if (room != null)
-            {
-                room.PlayerEntered -= RefreshMinimapWhenPlayerEnteredRoom;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Use SecurityCamera to refresh the minimap when the player moves
- Remove room-based minimap refresh logic

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c4e5dc96c832480817c864bfdbe8f