### PR TITLE
Add hint tracking and variable display durations

### DIFF
--- a/Assets/Scripts/UI/MessageSystem/MessageService.cs
+++ b/Assets/Scripts/UI/MessageSystem/MessageService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -7,8 +8,9 @@ public class MessageService : MonoBehaviour
 
     private Label messageLabel;
     private VisualElement root;
+    private readonly HashSet<GameMessage> displayedHints = new();
 
-    public bool IsNotDisplaying => messageLabel.style.display == DisplayStyle.None;
+    public bool IsNotDisplaying => messageLabel == null || messageLabel.style.display == DisplayStyle.None;
 
     private void Awake()
     {
@@ -26,7 +28,12 @@ public class MessageService : MonoBehaviour
         messageLabel = root.Q<Label>("GameMessageLabel");
     }
 
-    public void ShowMessage(GameMessage message, float duration = 5f)
+    /// <summary>
+    /// Displays a game message for the specified duration.
+    /// </summary>
+    /// <param name="message">The message to display.</param>
+    /// <param name="duration">How long to display the message.</param>
+    public void ShowMessage(GameMessage message, float duration = 6f)
     {
         if (messageLabel == null) return;
 
@@ -45,9 +52,29 @@ public class MessageService : MonoBehaviour
         Invoke(nameof(HideMessage), duration);
     }
 
+    /// <summary>
+    /// Hides any currently displayed message immediately.
+    /// </summary>
     public void HideMessage()
     {
+        CancelInvoke(nameof(HideMessage));
         if (messageLabel != null)
             messageLabel.style.display = DisplayStyle.None;
+    }
+
+    /// <summary>
+    /// Displays a hint message if it hasn't been shown before or if forced.
+    /// </summary>
+    /// <param name="id">The hint message to display.</param>
+    /// <param name="duration">Optional duration override.</param>
+    /// <param name="force">Show even if previously displayed.</param>
+    public void ShowHint(GameMessage id, float? duration = null, bool force = false)
+    {
+        if (!force && displayedHints.Contains(id))
+            return;
+
+        displayedHints.Add(id);
+        float showDuration = duration ?? Random.Range(6f, 8f);
+        ShowMessage(id, showDuration);
     }
 }


### PR DESCRIPTION
## Summary
- Add set of displayed hints and a new `ShowHint` method with optional duration and force parameters
- Allow messages to hide early and update `IsNotDisplaying` to account for null labels
- Default message duration to 6s and randomize hint duration between 6–8s

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c5650963883248df9b9262b1c988a