### PR TITLE
Use HintManager to present initial gameplay hints

### DIFF
--- a/Assets/Scripts/Game/HintManager.cs
+++ b/Assets/Scripts/Game/HintManager.cs
@@ -40,6 +40,8 @@ public class HintManager : MonoBehaviour
 
     private HintType? activeHint = null;
     private Coroutine clearHintCoroutine;
+    private readonly Queue<GameMessage> queuedHints = new();
+    private bool processingQueue = false;
 
     [Header("References")]
     [SerializeField] private MonoBehaviour inputSource;
@@ -70,6 +72,35 @@ public class HintManager : MonoBehaviour
     {
         if (health != null)
             health.OnHealthChanged -= HandleHealthChanged;
+    }
+
+    /// <summary>
+    /// Queues a hint to be displayed in order without overlapping others.
+    /// </summary>
+    /// <param name="hint">The hint message to display.</param>
+    public void QueueHint(GameMessage hint)
+    {
+        if (hint == null)
+            return;
+
+        queuedHints.Enqueue(hint);
+
+        if (!processingQueue)
+            StartCoroutine(ProcessQueuedHints());
+    }
+
+    private IEnumerator ProcessQueuedHints()
+    {
+        processingQueue = true;
+
+        while (queuedHints.Count > 0)
+        {
+            var nextHint = queuedHints.Dequeue();
+            MessageService.Instance?.ShowHint(nextHint, 7f);
+            yield return new WaitForSeconds(7f);
+        }
+
+        processingQueue = false;
     }
 
     private void Update()

--- a/Assets/Scripts/UI/GameUIViewModel.cs
+++ b/Assets/Scripts/UI/GameUIViewModel.cs
@@ -100,18 +100,13 @@ public class GameUIViewModel : MonoBehaviour
     }
     private void Start()
     {
-        var startMessage = GameMessages.System.Start;
-        string levelPrefix = string.Empty;
+        var hintManager = FindObjectOfType<HintManager>();
 
-        if (RunProgressManager.Instance != null)
+        if (hintManager != null)
         {
-            int index = RunProgressManager.Instance.CurrentLevelIndex;
-            var realLevel = index - 1;
-            levelPrefix = index == 1 ? "Level Tutorial. " : $"Level {realLevel}: ";
+            hintManager.QueueHint(new GameMessage("Move with [A][D]...", MessageSpeaker.Narrator));
+            hintManager.QueueHint(new GameMessage("Energy powers your actions.", MessageSpeaker.Narrator));
         }
-
-        var msg = new GameMessage(levelPrefix + startMessage.Text, startMessage.Speaker);
-        MessageService.Instance?.ShowMessage(msg);
     }
 
     public void SetPlayer(RobotStateController robot)


### PR DESCRIPTION
## Summary
- Start view model queues movement and energy tips via HintManager instead of System start message
- HintManager gains a simple queued-hint system so tips display sequentially

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c574cbeb4832494818b1f87e4536b