### PR TITLE
Fix root Rigidbody retrieval in Hinge2DIkSolver

### DIFF
--- a/Assets/Scripts/Robots/Hinge2DIkSolver.cs
+++ b/Assets/Scripts/Robots/Hinge2DIkSolver.cs
@@ -113,9 +113,13 @@ public class Hinge2DIkSolver : MonoBehaviour {
             current = current.connectedBody.GetComponent<AnchoredJoint2D> ();
         }
         root = bones[0].connectedBody.transform;
-        rootrb = root.GetComponent<Rigidbody2D> ();
+        rootrb = root.GetComponent<Rigidbody2D>();
         if (!rootrb) {
-            rootrb = rootrb.GetComponentInParent<Rigidbody2D> ();
+            rootrb = root.GetComponentInParent<Rigidbody2D>();
+        }
+        if (!rootrb) {
+            Debug.LogError("Hinge2DIkSolver: Root object is missing a Rigidbody2D. Solver disabled.", this);
+            enabled = false;
         }
 
         for (int i = 1; i <= chainLength; i++) {


### PR DESCRIPTION
## Summary
- fix Hinge2DIkSolver to search for Rigidbody2D using root transform instead of null reference
- log error and disable solver when Rigidbody2D is missing

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c58f237bc8324a7d7e18f473a341a