### PR TITLE
Handle low velocity in ApplyByTorque

### DIFF
--- a/Assets/Scripts/Robots/Hinge2DIkSolver.cs
+++ b/Assets/Scripts/Robots/Hinge2DIkSolver.cs
@@ -258,8 +258,9 @@ public class Hinge2DIkSolver : MonoBehaviour {
             }
             return;
         }
-        float vmd = 10 / rootrb.linearVelocity.sqrMagnitude;
-        vmd = Mathf.Clamp01 (vmd);
+        float sqrVel = rootrb.linearVelocity.sqrMagnitude;
+        float vmd = sqrVel <= Mathf.Epsilon ? 1f : 10f / sqrVel;
+        vmd = Mathf.Clamp01(vmd);
         var fxs50 = 25 * Time.fixedDeltaTime;
         for (int i = 1; i <= chainLength; i++) {
             if (!IsValidBone(i - 1) || bonesR == null || bonesR[i - 1] == null) {


### PR DESCRIPTION
## Summary
- Avoid divide-by-zero in Hinge2DIkSolver.ApplyByTorque by safely handling tiny root velocity

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c5b8e664c83248dc4dfd40a4f5c9a