### PR TITLE
Detach security badge from enemy hierarchy when grabbed

### DIFF
--- a/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
@@ -112,6 +112,10 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
             ownerInventory = inventory;
         }
 
+        // Detach from any previous hierarchy so the badge is no longer
+        // parented to an enemy when picked up.
+        transform.SetParent(grabParent.root, worldPositionStays: true);
+
         if (player != null)
         {
             var hip = player.BodyReference;
@@ -141,6 +145,9 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
         if (joint != null)
             joint.enabled = false;
         followTarget = null;
+
+        // Re-parent to world root so it no longer follows any holder.
+        transform.SetParent(null, worldPositionStays: true);
 
         if (ownerInventory != null)
         {


### PR DESCRIPTION
## Summary
- Ensure security badge transforms move to the player's root when grabbed
- Re-parent badge to world root when released to avoid following owners

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c5dee7f1c8324b68f13bbdc034287