### PR TITLE
Fix enemy badge respawn after theft

### DIFF
--- a/Assets/Editor/UnitTests/SecurityBadgeTheftTests.cs
+++ b/Assets/Editor/UnitTests/SecurityBadgeTheftTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using UnityEngine;
 using System.Reflection;
+using System.Collections.Generic;
 
 public class SecurityBadgeTheftTests
 {
@@ -52,5 +53,87 @@ public class SecurityBadgeTheftTests
         Application.logMessageReceived -= handler;
 
         Assert.AreEqual(1, chaseCalls);
+    }
+
+    private class DummyWaypointQueries : IWaypointQueries
+    {
+        public List<RoomWaypoint> GetAllWaypoints() => new();
+        public List<RoomWaypoint> GetActiveWaypoints() => new();
+        public List<RoomWaypoint> FindWorldPath(RoomWaypoint start, RoomWaypoint end) => new();
+        public RoomWaypoint GetClosestWaypoint(Vector2 position, bool includeUnavailable = false) => null;
+        public RoomWaypoint GetEndPoint() => null;
+        public RoomWaypoint GetStartPoint() => null;
+        public void UpdateClosestWaypointToPlayer(Vector2 playerPosition) { }
+        public RoomWaypoint ClosestWaypointToPlayer => null;
+    }
+
+    private class DummyWaypointNotifier : IWaypointNotifier
+    {
+        public void Subscribe(IRobotNavigationListener robot) { }
+        public void Unsubscribe(IRobotNavigationListener robot) { }
+        public void NotifyWaypointStatusChanged(RoomWaypoint changed, bool isAvailable) { }
+    }
+
+    private class DummyRespawnService : IRobotRespawnService
+    {
+        public void RespawnWorker() { }
+        public void RespawnBoss() { }
+    }
+
+    [Test]
+    public void Initialize_SpawnsNewBadgeAfterSteal()
+    {
+        // Enemy setup
+        var enemyGO = new GameObject("enemy");
+        enemyGO.AddComponent<EnemyStateMachine>();
+        enemyGO.AddComponent<RobotStateController>();
+        var enemy = enemyGO.AddComponent<EnemyController>();
+        typeof(EnemyController)
+            .GetField("bodyReference", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(enemy, enemyGO.transform);
+
+        // Badge prefab and spawner
+        var badgePrefabGO = new GameObject("badgePrefab");
+        badgePrefabGO.AddComponent<Rigidbody2D>();
+        badgePrefabGO.AddComponent<TargetJoint2D>();
+        var badgePrefab = badgePrefabGO.AddComponent<SecurityBadgePickup>();
+
+        var spawnerGO = new GameObject("spawner");
+        var spawner = spawnerGO.AddComponent<SecurityBadgeSpawner>();
+        typeof(SecurityBadgeSpawner)
+            .GetField("badgePrefab", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(spawner, badgePrefab);
+
+        var dropContainer = new GameObject("drop").transform;
+
+        // Stub services
+        var queries = new DummyWaypointQueries();
+        var notifier = new DummyWaypointNotifier();
+        var respawn = new DummyRespawnService();
+
+        enemy.Initialize(queries, notifier, respawn, dropContainer, spawner, true);
+        var enemyInventory = enemyGO.GetComponent<Inventory>();
+        var firstBadge = enemyInventory.GetItem(PickupType.SecurityBadge) as SecurityBadgePickup;
+        Assert.IsNotNull(firstBadge);
+
+        // Player to steal the badge
+        var playerGO = new GameObject("player");
+        var playerInv = playerGO.AddComponent<Inventory>();
+        var playerBody = playerGO.AddComponent<Rigidbody2D>();
+        var player = playerGO.AddComponent<DummyPlayerMovementController>();
+        typeof(PlayerMovementController)
+            .GetField("bodyReference", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(player, playerBody);
+        var hand = new GameObject("hand").transform;
+        hand.SetParent(playerGO.transform);
+
+        firstBadge.OnGrab(hand);
+
+        Assert.IsNull(enemyInventory.GetItem(PickupType.SecurityBadge));
+
+        enemy.Initialize(queries, notifier, respawn, dropContainer, spawner, true);
+        var secondBadge = enemyInventory.GetItem(PickupType.SecurityBadge) as SecurityBadgePickup;
+        Assert.IsNotNull(secondBadge);
+        Assert.AreNotSame(firstBadge, secondBadge);
     }
 }

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -222,6 +222,19 @@ public class EnemyController : PhysicsBaseAgentController, IPooledObject
         Debug.Log($"{name} badge stolen by {player.name}");
     }
 
+    /// <summary>
+    /// Handles cleanup when this enemy's security badge has been stolen.
+    /// Removes the badge from the inventory and clears the reference so a new
+    /// badge will be spawned on the next initialization.
+    /// </summary>
+    public void HandleBadgeStolen()
+    {
+        if (inventory != null)
+            inventory.RemoveItem(PickupType.SecurityBadge);
+
+        initialBadge = null;
+    }
+
 
 
     private void UpdateBalance(bool enabledBalance)

--- a/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
@@ -87,11 +87,12 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
     {
         var inventory = grabParent.GetComponentInParent<Inventory>();
         var player = grabParent.GetComponentInParent<PlayerMovementController>();
+        EnemyController enemy = null;
 
         // Detect if we're stealing from an enemy
         if (!wasStolen && transform.parent != null)
         {
-            var enemy = transform.parent.GetComponentInParent<EnemyController>();
+            enemy = transform.parent.GetComponentInParent<EnemyController>();
             if (enemy != null)
             {
                 var stateController = enemy.GetComponent<RobotStateController>();
@@ -115,6 +116,12 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
         // Detach from any previous hierarchy so the badge is no longer
         // parented to an enemy when picked up.
         transform.SetParent(grabParent.root, worldPositionStays: true);
+
+        if (wasStolen && enemy != null && player != null)
+        {
+            enemy.HandleBadgeStolen();
+            enemy.OnBadgeStolen(player.gameObject);
+        }
 
         if (player != null)
         {


### PR DESCRIPTION
## Summary
- add `HandleBadgeStolen` to `EnemyController` to clear badge and inventory
- invoke enemy badge handling from `SecurityBadgePickup` when stolen
- add test ensuring reinitialized enemies get a fresh badge

## Testing
- `bash setup_env.sh` *(fails: Package 'libasound2' has no installation candidate)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c5f08329483249339d11cadbd2f0b