### PR TITLE
Notify enemy when badge stolen before flagging

### DIFF
--- a/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
@@ -98,6 +98,7 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
                 var stateController = enemy.GetComponent<RobotStateController>();
                 if (stateController != null && stateController.CurrentState != RobotState.Dead && player != null)
                 {
+                    enemy.OnBadgeStolen(player.gameObject);
                     wasStolen = true;
                 }
             }
@@ -120,7 +121,6 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
         if (wasStolen && enemy != null && player != null)
         {
             enemy.HandleBadgeStolen();
-            enemy.OnBadgeStolen(player.gameObject);
         }
 
         if (player != null)


### PR DESCRIPTION
## Summary
- Notify the enemy when the player steals the security badge before marking it as stolen
- Avoid duplicate notifications for badge theft on subsequent grabs

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c609361988324a2bc6f972a34e826