### PR TITLE
Zero out battery physics when attached

### DIFF
--- a/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
@@ -43,6 +43,12 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
             return;
 
         joint.target = followTarget.position;
+
+        if (attached)
+        {
+            rb.velocity = Vector2.zero;
+            rb.angularVelocity = 0f;
+        }
     }
 
     public void SetFollowTarget(Transform target)


### PR DESCRIPTION
## Summary
- Stop residual physics from shaking the battery by clearing velocity and angular velocity while attached

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c6374d9288324a05f8d55ff46fd2e