### PR TITLE
Set battery to kinematic while held

### DIFF
--- a/Assets/Editor/UnitTests/BatteryPickupTests.cs
+++ b/Assets/Editor/UnitTests/BatteryPickupTests.cs
@@ -51,4 +51,25 @@ public class BatteryPickupTests
         inventory.DropItem(PickupType.Battery);
         Assert.IsFalse(inventory.HasItem(PickupType.Battery));
     }
+
+    [Test]
+    public void Battery_DisablesPhysicsWhileGrabbed()
+    {
+        var batteryGO = new GameObject("battery");
+        var rb = batteryGO.AddComponent<Rigidbody2D>();
+        rb.gravityScale = 2f;
+        batteryGO.AddComponent<TargetJoint2D>();
+        var battery = batteryGO.AddComponent<BatteryPickup>();
+        var hand = new GameObject("hand").transform;
+
+        battery.OnGrab(hand);
+
+        Assert.AreEqual(RigidbodyType2D.Kinematic, rb.bodyType);
+        Assert.AreEqual(0f, rb.gravityScale);
+
+        battery.OnRelease(Vector2.zero);
+
+        Assert.AreEqual(RigidbodyType2D.Dynamic, rb.bodyType);
+        Assert.AreEqual(2f, rb.gravityScale);
+    }
 }

--- a/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
@@ -19,12 +19,14 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
     private Transform followTarget;
     private bool attached = false;
     private bool wasStolen = false;
+    private float originalGravityScale;
 
     private Inventory ownerInventory;
 
     private void Awake()
     {
         rb = GetComponent<Rigidbody2D>();
+        originalGravityScale = rb.gravityScale;
         joint = GetComponent<TargetJoint2D>();
         if (joint != null)
         {
@@ -101,6 +103,8 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
 
         attached = true;
         rb.simulated = true;
+        rb.bodyType = RigidbodyType2D.Kinematic;
+        rb.gravityScale = 0f;
 
         var holderState = grabParent.GetComponentInParent<RobotStateController>();
         if (holderState != null)
@@ -146,6 +150,8 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
 
         if (rb != null)
         {
+            rb.bodyType = RigidbodyType2D.Dynamic;
+            rb.gravityScale = originalGravityScale;
             rb.simulated = true;
         }
         else


### PR DESCRIPTION
## Summary
- Disable gravity and switch battery rigidbody to kinematic when grabbed
- Restore dynamic body type and gravity once released
- Verify physics behavior with new unit test

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c641373d08324b2ac535c9f2af316