### PR TITLE
Expose joint tuning parameters

### DIFF
--- a/Assets/Resources/Prefabs/intereableObjects/BadgeSecurity.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/BadgeSecurity.prefab
@@ -131,9 +131,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   throwStrength: 5
-  frequency: 5
-  dampingRatio: 0.8
-  maxForce: 1000
+  frequency: 10
+  dampingRatio: 0.9
+  maxForce: 2000
 --- !u!257 &7876967260955353992
 TargetJoint2D:
   m_ObjectHideFlags: 0
@@ -151,9 +151,9 @@ TargetJoint2D:
   m_Anchor: {x: 0, y: 0}
   m_Target: {x: 6.3415685, y: 0.81}
   m_AutoConfigureTarget: 0
-  m_MaxForce: 10000
-  m_DampingRatio: 1
-  m_Frequency: 5
+  m_MaxForce: 2000
+  m_DampingRatio: 0.9
+  m_Frequency: 10
 --- !u!61 &3403505193419145802
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/intereableObjects/Battery+10.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/Battery+10.prefab
@@ -131,9 +131,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   healthGain: 10
-  frequency: 5
-  dampingRatio: 0.8
-  maxForce: 1000
+  frequency: 10
+  dampingRatio: 0.9
+  maxForce: 2000
 --- !u!257 &7876967260955353992
 TargetJoint2D:
   m_ObjectHideFlags: 0
@@ -151,9 +151,9 @@ TargetJoint2D:
   m_Anchor: {x: 0, y: 0}
   m_Target: {x: 6.3415685, y: 0.81}
   m_AutoConfigureTarget: 0
-  m_MaxForce: 10000
-  m_DampingRatio: 1
-  m_Frequency: 5
+  m_MaxForce: 2000
+  m_DampingRatio: 0.9
+  m_Frequency: 10
 --- !u!61 &2933447607757072381
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/intereableObjects/Battery+20.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/Battery+20.prefab
@@ -131,9 +131,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   healthGain: 10
-  frequency: 5
-  dampingRatio: 0.8
-  maxForce: 1000
+  frequency: 10
+  dampingRatio: 0.9
+  maxForce: 2000
 --- !u!257 &7876967260955353992
 TargetJoint2D:
   m_ObjectHideFlags: 0
@@ -151,9 +151,9 @@ TargetJoint2D:
   m_Anchor: {x: 0, y: 0}
   m_Target: {x: 6.3415685, y: 0.81}
   m_AutoConfigureTarget: 0
-  m_MaxForce: 10000
-  m_DampingRatio: 1
-  m_Frequency: 5
+  m_MaxForce: 2000
+  m_DampingRatio: 0.9
+  m_Frequency: 10
 --- !u!61 &2933447607757072381
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/intereableObjects/Battery+30.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/Battery+30.prefab
@@ -131,9 +131,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   healthGain: 10
-  frequency: 5
-  dampingRatio: 0.8
-  maxForce: 1000
+  frequency: 10
+  dampingRatio: 0.9
+  maxForce: 2000
 --- !u!257 &7876967260955353992
 TargetJoint2D:
   m_ObjectHideFlags: 0
@@ -151,9 +151,9 @@ TargetJoint2D:
   m_Anchor: {x: 0, y: 0}
   m_Target: {x: 6.3415685, y: 0.81}
   m_AutoConfigureTarget: 0
-  m_MaxForce: 10000
-  m_DampingRatio: 1
-  m_Frequency: 5
+  m_MaxForce: 2000
+  m_DampingRatio: 0.9
+  m_Frequency: 10
 --- !u!61 &2933447607757072381
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/intereableObjects/Battery+40.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/Battery+40.prefab
@@ -131,9 +131,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   healthGain: 10
-  frequency: 5
-  dampingRatio: 0.8
-  maxForce: 1000
+  frequency: 10
+  dampingRatio: 0.9
+  maxForce: 2000
 --- !u!257 &7876967260955353992
 TargetJoint2D:
   m_ObjectHideFlags: 0
@@ -151,9 +151,9 @@ TargetJoint2D:
   m_Anchor: {x: 0, y: 0}
   m_Target: {x: 6.3415685, y: 0.81}
   m_AutoConfigureTarget: 0
-  m_MaxForce: 10000
-  m_DampingRatio: 1
-  m_Frequency: 5
+  m_MaxForce: 2000
+  m_DampingRatio: 0.9
+  m_Frequency: 10
 --- !u!61 &2933447607757072381
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/intereableObjects/CubeAttackDamage.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/CubeAttackDamage.prefab
@@ -136,9 +136,9 @@ TargetJoint2D:
   m_Anchor: {x: 0, y: 0}
   m_Target: {x: 6.3415685, y: 0.81}
   m_AutoConfigureTarget: 0
-  m_MaxForce: 10000
-  m_DampingRatio: 1
-  m_Frequency: 5
+  m_MaxForce: 2000
+  m_DampingRatio: 0.9
+  m_Frequency: 10
 --- !u!61 &2933447607757072381
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -210,6 +210,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 413bbe5d24595fb4dbe8e97033614dcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 5
-  dampingRatio: 0.8
-  maxForce: 1000
+  frequency: 10
+  dampingRatio: 0.9
+  maxForce: 2000

--- a/Assets/Resources/Prefabs/intereableObjects/CubeMaxEnergy.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/CubeMaxEnergy.prefab
@@ -136,9 +136,9 @@ TargetJoint2D:
   m_Anchor: {x: 0, y: 0}
   m_Target: {x: 6.3415685, y: 0.81}
   m_AutoConfigureTarget: 0
-  m_MaxForce: 10000
-  m_DampingRatio: 1
-  m_Frequency: 5
+  m_MaxForce: 2000
+  m_DampingRatio: 0.9
+  m_Frequency: 10
 --- !u!61 &2933447607757072381
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -210,6 +210,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 413bbe5d24595fb4dbe8e97033614dcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 5
-  dampingRatio: 0.8
-  maxForce: 1000
+  frequency: 10
+  dampingRatio: 0.9
+  maxForce: 2000

--- a/Assets/Resources/Prefabs/intereableObjects/CubeMaxHealth.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/CubeMaxHealth.prefab
@@ -136,9 +136,9 @@ TargetJoint2D:
   m_Anchor: {x: 0, y: 0}
   m_Target: {x: 6.3415685, y: 0.81}
   m_AutoConfigureTarget: 0
-  m_MaxForce: 10000
-  m_DampingRatio: 1
-  m_Frequency: 5
+  m_MaxForce: 2000
+  m_DampingRatio: 0.9
+  m_Frequency: 10
 --- !u!61 &2933447607757072381
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -210,6 +210,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 413bbe5d24595fb4dbe8e97033614dcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 5
-  dampingRatio: 0.8
-  maxForce: 1000
+  frequency: 10
+  dampingRatio: 0.9
+  maxForce: 2000

--- a/Assets/Resources/Prefabs/intereableObjects/CubeNormal.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/CubeNormal.prefab
@@ -135,9 +135,9 @@ TargetJoint2D:
   m_Anchor: {x: 0, y: 0}
   m_Target: {x: 6.3415685, y: 0.81}
   m_AutoConfigureTarget: 0
-  m_MaxForce: 10000
-  m_DampingRatio: 1
-  m_Frequency: 5
+  m_MaxForce: 2000
+  m_DampingRatio: 0.9
+  m_Frequency: 10
 --- !u!61 &2933447607757072381
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -196,6 +196,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 413bbe5d24595fb4dbe8e97033614dcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 5
-  dampingRatio: 0.8
-  maxForce: 1000
+  frequency: 10
+  dampingRatio: 0.9
+  maxForce: 2000

--- a/Assets/Resources/Prefabs/intereableObjects/CubeReloadEnergy.prefab
+++ b/Assets/Resources/Prefabs/intereableObjects/CubeReloadEnergy.prefab
@@ -136,9 +136,9 @@ TargetJoint2D:
   m_Anchor: {x: 0, y: 0}
   m_Target: {x: 6.3415685, y: 0.81}
   m_AutoConfigureTarget: 0
-  m_MaxForce: 10000
-  m_DampingRatio: 1
-  m_Frequency: 5
+  m_MaxForce: 2000
+  m_DampingRatio: 0.9
+  m_Frequency: 10
 --- !u!61 &2933447607757072381
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -210,6 +210,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 413bbe5d24595fb4dbe8e97033614dcb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frequency: 5
-  dampingRatio: 0.8
-  maxForce: 1000
+  frequency: 10
+  dampingRatio: 0.9
+  maxForce: 2000

--- a/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
@@ -7,12 +7,54 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
     [SerializeField] private float healthGain = 10f;
 
     [Header("Target Joint Settings")]
-    [Tooltip("How springy the joint movement is.")]
-    [SerializeField] private float frequency = 5f;
-    [Tooltip("How much the joint resists oscillation.")]
-    [SerializeField] private float dampingRatio = 0.8f;
-    [Tooltip("Maximum force the joint can apply.")]
-    [SerializeField] private float maxForce = 1000f;
+    [Tooltip("How springy the joint movement is. Recommended range: 5–15.")]
+    [SerializeField, Range(5f, 15f)] private float frequency = 10f;
+    [Tooltip("How much the joint resists oscillation. Recommended range: 0–1.")]
+    [SerializeField, Range(0f, 1f)] private float dampingRatio = 0.9f;
+    [Tooltip("Maximum force the joint can apply. Recommended range: 500–3000.")]
+    [SerializeField, Range(500f, 3000f)] private float maxForce = 2000f;
+
+    /// <summary>
+    /// How springy the joint movement is.
+    /// </summary>
+    public float Frequency
+    {
+        get => frequency;
+        set
+        {
+            frequency = value;
+            if (joint != null)
+                joint.frequency = frequency;
+        }
+    }
+
+    /// <summary>
+    /// How much the joint resists oscillation.
+    /// </summary>
+    public float DampingRatio
+    {
+        get => dampingRatio;
+        set
+        {
+            dampingRatio = value;
+            if (joint != null)
+                joint.dampingRatio = dampingRatio;
+        }
+    }
+
+    /// <summary>
+    /// Maximum force the joint can apply.
+    /// </summary>
+    public float MaxForce
+    {
+        get => maxForce;
+        set
+        {
+            maxForce = value;
+            if (joint != null)
+                joint.maxForce = maxForce;
+        }
+    }
 
     private Rigidbody2D rb;
     private TargetJoint2D joint;

--- a/Assets/Scripts/Player/GrabSystem/CubePickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/CubePickup.cs
@@ -6,12 +6,54 @@ public class CubePickup : MonoBehaviour, IGrabbable
 {
 
     [Header("Target Joint Settings")]
-    [Tooltip("How springy the joint movement is.")]
-    [SerializeField] private float frequency = 5f;
-    [Tooltip("How much the joint resists oscillation.")]
-    [SerializeField] private float dampingRatio = 0.8f;
-    [Tooltip("Maximum force the joint can apply.")]
-    [SerializeField] private float maxForce = 1000f;
+    [Tooltip("How springy the joint movement is. Recommended range: 5–15.")]
+    [SerializeField, Range(5f, 15f)] private float frequency = 10f;
+    [Tooltip("How much the joint resists oscillation. Recommended range: 0–1.")]
+    [SerializeField, Range(0f, 1f)] private float dampingRatio = 0.9f;
+    [Tooltip("Maximum force the joint can apply. Recommended range: 500–3000.")]
+    [SerializeField, Range(500f, 3000f)] private float maxForce = 2000f;
+
+    /// <summary>
+    /// How springy the joint movement is.
+    /// </summary>
+    public float Frequency
+    {
+        get => frequency;
+        set
+        {
+            frequency = value;
+            if (joint != null)
+                joint.frequency = frequency;
+        }
+    }
+
+    /// <summary>
+    /// How much the joint resists oscillation.
+    /// </summary>
+    public float DampingRatio
+    {
+        get => dampingRatio;
+        set
+        {
+            dampingRatio = value;
+            if (joint != null)
+                joint.dampingRatio = dampingRatio;
+        }
+    }
+
+    /// <summary>
+    /// Maximum force the joint can apply.
+    /// </summary>
+    public float MaxForce
+    {
+        get => maxForce;
+        set
+        {
+            maxForce = value;
+            if (joint != null)
+                joint.maxForce = maxForce;
+        }
+    }
 
     private Rigidbody2D rb;
     private TargetJoint2D joint;

--- a/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/SecurityBadgePickup.cs
@@ -7,12 +7,54 @@ public class SecurityBadgePickup : MonoBehaviour, IGrabbable
     public float throwStrength = 5f;
 
     [Header("Target Joint Settings")]
-    [Tooltip("How springy the joint movement is.")]
-    [SerializeField] private float frequency = 5f;
-    [Tooltip("How much the joint resists oscillation.")]
-    [SerializeField] private float dampingRatio = 0.8f;
-    [Tooltip("Maximum force the joint can apply.")]
-    [SerializeField] private float maxForce = 1000f;
+    [Tooltip("How springy the joint movement is. Recommended range: 5–15.")]
+    [SerializeField, Range(5f, 15f)] private float frequency = 10f;
+    [Tooltip("How much the joint resists oscillation. Recommended range: 0–1.")]
+    [SerializeField, Range(0f, 1f)] private float dampingRatio = 0.9f;
+    [Tooltip("Maximum force the joint can apply. Recommended range: 500–3000.")]
+    [SerializeField, Range(500f, 3000f)] private float maxForce = 2000f;
+
+    /// <summary>
+    /// How springy the joint movement is.
+    /// </summary>
+    public float Frequency
+    {
+        get => frequency;
+        set
+        {
+            frequency = value;
+            if (joint != null)
+                joint.frequency = frequency;
+        }
+    }
+
+    /// <summary>
+    /// How much the joint resists oscillation.
+    /// </summary>
+    public float DampingRatio
+    {
+        get => dampingRatio;
+        set
+        {
+            dampingRatio = value;
+            if (joint != null)
+                joint.dampingRatio = dampingRatio;
+        }
+    }
+
+    /// <summary>
+    /// Maximum force the joint can apply.
+    /// </summary>
+    public float MaxForce
+    {
+        get => maxForce;
+        set
+        {
+            maxForce = value;
+            if (joint != null)
+                joint.maxForce = maxForce;
+        }
+    }
 
     Rigidbody2D rb;
     TargetJoint2D joint;


### PR DESCRIPTION
## Summary
- expose frequency, damping ratio, and max force via public properties
- raise default joint strength to damp oscillations and document recommended ranges
- update item prefabs with new tuning defaults

## Testing
- `bash setup_env.sh` *(failed: Package 'libasound2' has no installation candidate)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c665f39248324ac00cf120f02e0d3