### PR TITLE
Attach battery to player on grab

### DIFF
--- a/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
@@ -143,6 +143,8 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
             }
         }
 
+        transform.SetParent(grabParent, true);
+
         attached = true;
         rb.simulated = true;
         rb.bodyType = RigidbodyType2D.Kinematic;
@@ -189,6 +191,7 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
             joint.enabled = false;
 
         followTarget = null;
+        transform.SetParent(null, true);
 
         if (rb != null)
         {


### PR DESCRIPTION
## Summary
- Parent battery to player when grabbed so it moves with the player
- Detach battery from player when released to rest in world

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c6c2a15e48324b2fa9d0c69561c78