### PR TITLE
Handle enemy battery state when battery stolen

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
@@ -137,6 +137,17 @@ public class EnemyWorkerController : AnimatorBaseAgentController, IPooledObject
         robotBehaviour.Stats.UpdateEnergy(robotBehaviour.Stats.CurrentEnergy);
     }
 
+    /// <summary>
+    /// Removes the stolen battery from the inventory and clears the initial reference.
+    /// </summary>
+    public void HandleBatteryStolen()
+    {
+        if (inventory != null)
+            inventory.RemoveItem(PickupType.Battery);
+
+        initialBattery = null;
+    }
+
     private void FixedUpdate()
     {
         if (updateLoop == UpdateLoop.FixedUpdate)

--- a/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
@@ -138,6 +138,7 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
                 if (stateController != null && stateController.CurrentState != RobotState.Dead && player != null)
                 {
                     enemy.OnBatteryStolen(player.gameObject);
+                    enemy.HandleBatteryStolen();
                     wasStolen = true;
                 }
             }


### PR DESCRIPTION
## Summary
- Add `HandleBatteryStolen` method to `EnemyWorkerController` to drop battery from inventory and clear reference
- Invoke `HandleBatteryStolen` from `BatteryPickup` after notifying the enemy of theft

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c877adae883248279122983b43c3a