### PR TITLE
Adjust enemy health on battery theft

### DIFF
--- a/Assets/Editor/UnitTests/BatteryStealFromEnemyTests.cs
+++ b/Assets/Editor/UnitTests/BatteryStealFromEnemyTests.cs
@@ -45,10 +45,14 @@ public class BatteryStealFromEnemyTests
         enemyState.Stats = new RobotStats();
         enemyState.Stats.MaxHealth = 100f;
         enemyState.Stats.CurrentHealth = 50f;
-        enemyGO.AddComponent<EnemyStateMachine>();
-        var enemy = enemyGO.AddComponent<EnemyController>();
-        enemy.EnemyStatus = EnemyStatus.Idle;
-        var enemyInventory = enemyGO.GetComponent<Inventory>();
+        var enemyInventory = enemyGO.AddComponent<Inventory>();
+        var enemy = enemyGO.AddComponent<EnemyWorkerController>();
+        typeof(EnemyWorkerController)
+            .GetField("robotBehaviour", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(enemy, enemyState);
+        typeof(EnemyWorkerController)
+            .GetField("inventory", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(enemy, enemyInventory);
 
         var batteryGO = new GameObject("battery");
         batteryGO.transform.SetParent(enemyGO.transform);
@@ -103,7 +107,12 @@ public class BatteryStealFromEnemyTests
 
         Assert.AreEqual(battery, playerInventory.GetItem(PickupType.Battery));
         Assert.IsFalse(enemyInventory.HasItem(PickupType.Battery));
-        Assert.AreEqual(40f + 10f, playerState.Stats.CurrentHealth);
-        Assert.AreEqual(50f - 10f, enemyState.Stats.CurrentHealth);
+
+        var gain = (float)typeof(BatteryPickup)
+            .GetField("healthGain", BindingFlags.NonPublic | BindingFlags.Instance)
+            .GetValue(battery);
+
+        Assert.AreEqual(40f + gain, playerState.Stats.CurrentHealth);
+        Assert.AreEqual(50f - gain, enemyState.Stats.CurrentHealth);
     }
 }

--- a/Assets/Editor/UnitTests/BatteryTheftTests.cs
+++ b/Assets/Editor/UnitTests/BatteryTheftTests.cs
@@ -21,9 +21,10 @@ public class BatteryTheftTests
         enemyState.Stats = new RobotStats();
         enemyState.Stats.MaxHealth = 100f;
         enemyState.Stats.CurrentHealth = 50f;
-        enemyGO.AddComponent<EnemyStateMachine>();
-        var enemy = enemyGO.AddComponent<EnemyController>();
-        enemy.EnemyStatus = EnemyStatus.Idle;
+        var enemy = enemyGO.AddComponent<EnemyWorkerController>();
+        typeof(EnemyWorkerController)
+            .GetField("robotBehaviour", BindingFlags.NonPublic | BindingFlags.Instance)
+            .SetValue(enemy, enemyState);
 
         var batteryGO = new GameObject("battery");
         batteryGO.transform.SetParent(enemyGO.transform);
@@ -48,7 +49,11 @@ public class BatteryTheftTests
 
         battery.OnGrab(hand);
 
-        Assert.AreEqual(50f - 10f, enemyState.Stats.CurrentHealth);
-        Assert.AreEqual(40f + 10f, playerState.Stats.CurrentHealth);
+        var gain = (float)typeof(BatteryPickup)
+            .GetField("healthGain", BindingFlags.NonPublic | BindingFlags.Instance)
+            .GetValue(battery);
+
+        Assert.AreEqual(50f - gain, enemyState.Stats.CurrentHealth);
+        Assert.AreEqual(40f + gain, playerState.Stats.CurrentHealth);
     }
 }

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
@@ -131,10 +131,11 @@ public class EnemyWorkerController : AnimatorBaseAgentController, IPooledObject
             pathFollower?.Update(Time.deltaTime);
     }
 
-    public void OnBatteryStolen(GameObject player)
+    public void OnBatteryStolen(GameObject player, float healthGain)
     {
         Debug.Log($"{name} battery stolen by {player.name}");
         robotBehaviour.Stats.UpdateEnergy(robotBehaviour.Stats.CurrentEnergy);
+        robotBehaviour.Stats.UpdateHealth(-healthGain);
     }
 
     /// <summary>

--- a/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
+++ b/Assets/Scripts/Player/GrabSystem/BatteryPickup.cs
@@ -137,7 +137,7 @@ public class BatteryPickup : MonoBehaviour, IGrabbable
                 var stateController = enemy.GetComponent<RobotStateController>();
                 if (stateController != null && stateController.CurrentState != RobotState.Dead && player != null)
                 {
-                    enemy.OnBatteryStolen(player.gameObject);
+                    enemy.OnBatteryStolen(player.gameObject, healthGain);
                     enemy.HandleBatteryStolen();
                     wasStolen = true;
                 }


### PR DESCRIPTION
## Summary
- Drain enemy worker's health when its battery is stolen
- Pass stolen battery's health value to enemy and update tests for parity with player gain

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c89948b048324b0f5fa5407800bae