### PR TITLE
Offset start spawn position based on grid side

### DIFF
--- a/Assets/Editor/UnitTests/FactoryManagerTests.cs
+++ b/Assets/Editor/UnitTests/FactoryManagerTests.cs
@@ -32,16 +32,21 @@ public class FactoryManagerTests
     public void GetStartCellWorldPosition_ReturnsPosition()
     {
         var mapManager = new GameObject().AddComponent<MapManager>();
+        mapManager.cellWidth = 40;
+        typeof(MapManager).GetField("gridWidth", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(mapManager, 10);
+
         var startGO = new GameObject();
         startGO.transform.position = new Vector3(2, 3, 0);
         var props = startGO.AddComponent<RoomProperties>();
         props.usageType = UsageType.Start;
+        props.GridPosition = new Vector2Int(8, 0); // Right half of grid
         var dict = new System.Collections.Generic.Dictionary<Vector2, GameObject> { { Vector2.zero, startGO } };
         typeof(MapManager).GetField("roomInstances", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(mapManager, dict);
         typeof(FactoryManager).GetField("mapManager", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(_factoryManager, mapManager);
 
         var pos = _factoryManager.GetStartCellWorldPosition();
-        Assert.AreEqual(startGO.transform.position, pos);
+        var expected = startGO.transform.position + new Vector3(-mapManager.cellWidth * 0.25f, 0f, 0f);
+        Assert.AreEqual(expected, pos);
     }
 
     [Test]

--- a/Assets/Editor/UnitTests/MapManagerTests.cs
+++ b/Assets/Editor/UnitTests/MapManagerTests.cs
@@ -56,15 +56,20 @@ public class MapManagerTests
     [Test]
     public void GetStartCellWorldPosition_ReturnsStart()
     {
+        _manager.cellWidth = 40;
+        typeof(MapManager).GetField("gridWidth", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(_manager, 10);
+
         var startGO = new GameObject();
         startGO.transform.position = new Vector3(1, 1, 0);
         var props = startGO.AddComponent<RoomProperties>();
         props.usageType = UsageType.Start;
+        props.GridPosition = new Vector2Int(2, 0); // Left half of grid
         var dict = new System.Collections.Generic.Dictionary<Vector2, GameObject> { { Vector2.zero, startGO } };
         typeof(MapManager).GetField("roomInstances", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(_manager, dict);
 
         var pos = _manager.GetStartCellWorldPosition();
-        Assert.AreEqual(startGO.transform.position, pos);
+        var expected = startGO.transform.position + new Vector3(_manager.cellWidth * 0.25f, 0f, 0f);
+        Assert.AreEqual(expected, pos);
     }
 
     [Test]

--- a/Assets/Scripts/Interfaces/IFactoryManager.cs
+++ b/Assets/Scripts/Interfaces/IFactoryManager.cs
@@ -7,6 +7,9 @@ public interface IFactoryManager
 
     void Initialize(MapManager mapManager, IWaypointService waypointService, VictorySetup victorySetup, IEnemiesSpawner enemiesSpawner);
     IWaypointService GetWayPointService();
+    /// <summary>
+    /// Gets the world position of the start room, including its horizontal offset.
+    /// </summary>
     Vector3 GetStartCellWorldPosition();
     void SetPlayerInstanceHead(GameObject playerInstance, Transform head);
     void OnRobotSaved();

--- a/Assets/Scripts/Navigation/MapManager.cs
+++ b/Assets/Scripts/Navigation/MapManager.cs
@@ -233,6 +233,10 @@ public class MapManager : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Returns the world position of the start cell with a slight horizontal offset.
+    /// Rooms on the left half of the grid are nudged right; rooms on the right half are nudged left.
+    /// </summary>
     public Vector3 GetStartCellWorldPosition()
     {
         if (roomInstances == null)
@@ -244,8 +248,13 @@ public class MapManager : MonoBehaviour
             var roomProps = roomObj.GetComponent<RoomProperties>();
             if (roomProps != null && roomProps.usageType == UsageType.Start)
             {
-                // Return the center position of the cell (room)
-                return roomObj.transform.position;
+                Vector3 pos = roomObj.transform.position;
+                float offset = cellWidth * 0.25f;
+                if (roomProps.GridPosition.x < gridWidth / 2f)
+                    pos += new Vector3(offset, 0f, 0f);
+                else
+                    pos += new Vector3(-offset, 0f, 0f);
+                return pos;
             }
         }
         Debug.LogWarning("No start cell found in roomInstances.");


### PR DESCRIPTION
## Summary
- Offset start room spawn point left or right depending on its grid position
- Document start position retrieval in factory manager interface
- Update unit tests for new spawn offset logic

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*
- `dotnet test UnitTests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cab426f988324baaedac5fac609e4