### PR TITLE
Guard jump logic with input check

### DIFF
--- a/Assets/Scripts/Player/Controllers/NewPlayerMovementController.cs
+++ b/Assets/Scripts/Player/Controllers/NewPlayerMovementController.cs
@@ -75,7 +75,7 @@ public sealed class NewPlayerMovementController : MonoBehaviour, ILookDirectionP
 
     private void HandleJump()
     {
-        if (jumpAction.triggered && IsGrounded)
+        if (input != null && input.JumpPressed && IsGrounded)
         {
             rb.AddForce(Vector2.up * jumpForce, ForceMode2D.Impulse);
             IsGrounded = false;


### PR DESCRIPTION
## Summary
- Use player input's JumpPressed flag in NewPlayerMovementController.HandleJump
- Prevent jump force unless input is available, jump pressed, and character grounded

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found: unity)*

------
https://chatgpt.com/codex/tasks/task_e_689f049e45c88324ac03068d6d9eb63a