### PR TITLE
Remove unused PlayerInput field from NewPlayerMovementController

### DIFF
--- a/Assets/Scripts/Player/Controllers/NewPlayerMovementController.cs
+++ b/Assets/Scripts/Player/Controllers/NewPlayerMovementController.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.InputSystem;
 
 [RequireComponent(typeof(Animator))]
 public sealed class NewPlayerMovementController : MonoBehaviour, ILookDirectionProvider
@@ -22,7 +21,6 @@ public sealed class NewPlayerMovementController : MonoBehaviour, ILookDirectionP
     private Animator animator;
 
     // Input
-    private PlayerInput playerInput;
     private IPlayerInput input;
 
     private float moveInput;
@@ -46,7 +44,6 @@ public sealed class NewPlayerMovementController : MonoBehaviour, ILookDirectionP
     {
         if (!body) Debug.LogError("Assign a Rigidbody2D to 'body'.");
         animator = GetComponent<Animator>();
-        playerInput = GetComponent<PlayerInput>();
         input = GetComponent<IPlayerInput>();
 
         if (sprites == null || sprites.Length == 0)


### PR DESCRIPTION
## Summary
- clean up NewPlayerMovementController by removing unused PlayerInput component lookup

## Testing
- `dotnet build Game.csproj` *(fails: Metadata file 'Microsoft.Unity.Analyzers.dll' could not be found)*
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f303802fc8324b0236557a987ffd8