### PR TITLE
Preserve walk cycle when flipping direction

### DIFF
--- a/Assets/Scripts/Player/Controllers/NewPlayerMovementController.cs
+++ b/Assets/Scripts/Player/Controllers/NewPlayerMovementController.cs
@@ -102,7 +102,15 @@ public sealed class NewPlayerMovementController : MonoBehaviour, ILookDirectionP
     private void SetFacing(bool left)
     {
         if (facingLeft == left) return;
+
+        bool moving = Mathf.Abs(moveInput) > 0.01f;
         facingLeft = left;
+
+        if (moving)
+        {
+            float t = animator.GetCurrentAnimatorStateInfo(0).normalizedTime % 1f;
+            animator.Play("Walk", 0, (t + 0.5f) % 1f);
+        }
 
         // visuals
         if (sprites != null)


### PR DESCRIPTION
## Summary
- offset walk animation by 0.5 when player flips while moving to keep step timing

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f34cb22048324bce04e0bb936016c