### PR TITLE
Use raycast grounding and immediate idle/walk transitions

### DIFF
--- a/Assets/Resources/Prefabs/Robots/RobotPackage/NewPlayerAnimator.controller
+++ b/Assets/Resources/Prefabs/Robots/RobotPackage/NewPlayerAnimator.controller
@@ -19,7 +19,7 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0.05
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
+  m_ExitTime: 0
   m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
@@ -71,7 +71,7 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0.05
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
+  m_ExitTime: 0
   m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0

--- a/Assets/Scripts/Player/Controllers/NewPlayerMovementController.cs
+++ b/Assets/Scripts/Player/Controllers/NewPlayerMovementController.cs
@@ -15,8 +15,8 @@ public sealed class NewPlayerMovementController : MonoBehaviour, ILookDirectionP
 
     [Header("Physics targets")]
     [SerializeField] private Rigidbody2D body;      // hips/torso RB
-    [SerializeField] private Transform groundProbe; // empty under feet
-    [SerializeField] private float groundProbeRadius = 0.06f;
+    [SerializeField] private Transform groundProbe; // optional probe beneath feet
+    [SerializeField] private float groundCheckDistance = 0.06f;
 
     private Animator animator;
 
@@ -88,8 +88,10 @@ public sealed class NewPlayerMovementController : MonoBehaviour, ILookDirectionP
         v.x = moveInput * moveSpeed;
         body.linearVelocity = v;
 
-        if (groundProbe)
-            IsGrounded = Physics2D.OverlapCircle(groundProbe.position, groundProbeRadius, groundMask);
+        // Grounding check using a downward raycast or probe
+        Vector2 origin = groundProbe ? (Vector2)groundProbe.position : body.position;
+        RaycastHit2D hit = Physics2D.Raycast(origin, Vector2.down, groundCheckDistance, groundMask);
+        IsGrounded = hit.collider != null;
     }
 
     private void HandleJump()


### PR DESCRIPTION
## Summary
- Make Idle <-> Walk animation transitions instantaneous by removing exit time
- Check player grounding with a downward raycast, independent of facing direction

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f34cf9fe48324bf495148aafbf775