### PR TITLE
Cache hinge settings for flip

### DIFF
--- a/Assets/Editor/UnitTests/NewPlayerMovementControllerTests.cs
+++ b/Assets/Editor/UnitTests/NewPlayerMovementControllerTests.cs
@@ -18,12 +18,20 @@ public class NewPlayerMovementControllerTests
             var left = new GameObject("LeftLowLeg");
             left.transform.SetParent(go.transform);
             left.AddComponent<Rigidbody2D>();
-            left.AddComponent<HingeJoint2D>();
+            var leftJoint = left.AddComponent<HingeJoint2D>();
 
             var right = new GameObject("RightLowLeg");
             right.transform.SetParent(go.transform);
             right.AddComponent<Rigidbody2D>();
-            right.AddComponent<HingeJoint2D>();
+            var rightJoint = right.AddComponent<HingeJoint2D>();
+
+            var motor = rightJoint.motor;
+            motor.motorSpeed = 50f;
+            rightJoint.motor = motor;
+            var limits = rightJoint.limits;
+            limits.min = 0f;
+            limits.max = 180f;
+            rightJoint.limits = limits;
 
             limiter.RefreshJoints();
 
@@ -35,10 +43,12 @@ public class NewPlayerMovementControllerTests
             var method = typeof(NewPlayerMovementController).GetMethod("SetFacing", BindingFlags.NonPublic | BindingFlags.Instance);
 
             method.Invoke(controller, new object[] { true });
-            AssertJointLimits(limiter, 0f, 180f);
+            AssertJoint(limiter.rightLegJoint, 0f, 180f, 50f);
+            AssertJoint(limiter.leftLegJoint, -180f, 0f, -50f);
 
             method.Invoke(controller, new object[] { false });
-            AssertJointLimits(limiter, -180f, 0f);
+            AssertJoint(limiter.rightLegJoint, -180f, 0f, -50f);
+            AssertJoint(limiter.leftLegJoint, 0f, 180f, 50f);
 
             Object.DestroyImmediate(go);
         }
@@ -48,11 +58,10 @@ public class NewPlayerMovementControllerTests
         }
     }
 
-    private static void AssertJointLimits(LegJointLimiter limiter, float expectedMin, float expectedMax)
+    private static void AssertJoint(HingeJoint2D joint, float expectedMin, float expectedMax, float expectedSpeed)
     {
-        Assert.AreEqual(expectedMin, limiter.leftLegJoint.limits.min);
-        Assert.AreEqual(expectedMax, limiter.leftLegJoint.limits.max);
-        Assert.AreEqual(expectedMin, limiter.rightLegJoint.limits.min);
-        Assert.AreEqual(expectedMax, limiter.rightLegJoint.limits.max);
+        Assert.AreEqual(expectedMin, joint.limits.min);
+        Assert.AreEqual(expectedMax, joint.limits.max);
+        Assert.AreEqual(expectedSpeed, joint.motor.motorSpeed);
     }
 }

--- a/Assets/Scripts/Robots/LegJointLimiter.cs
+++ b/Assets/Scripts/Robots/LegJointLimiter.cs
@@ -7,28 +7,41 @@ public class LegJointLimiter : MonoBehaviour
     public HingeJoint2D leftLegJoint;
     public HingeJoint2D rightLegJoint;
 
+    private float minRight;
+    private float maxRight;
+    private float motorSpeedRight;
+    private bool cached;
+    private bool facingRight = true;
+
     private void Awake()
     {
         RefreshJoints();
+        CacheRightJoint();
     }
 
     public void SetLegRotationLimits(bool goingRight)
     {
-        if (goingRight)
+        if (!cached)
+            CacheRightJoint();
+
+        if (goingRight == facingRight)
+            return;
+
+        facingRight = goingRight;
+
+        if (facingRight)
         {
-            // Facing right: -180 to 0 for both legs
-            SetJointLimits(rightLegJoint, -180f, 0);
-            SetJointLimits(leftLegJoint, -180f, 0);
+            ApplyJoint(rightLegJoint, minRight, maxRight, motorSpeedRight);
+            ApplyJoint(leftLegJoint, -maxRight, -minRight, -motorSpeedRight);
         }
         else
         {
-            // Facing left: 0 to 180 for both legs
-            SetJointLimits(rightLegJoint, 0f, 180);
-            SetJointLimits(leftLegJoint, 0f, 180);
+            ApplyJoint(rightLegJoint, -maxRight, -minRight, -motorSpeedRight);
+            ApplyJoint(leftLegJoint, minRight, maxRight, motorSpeedRight);
         }
     }
 
-    private void SetJointLimits(HingeJoint2D joint, float lower, float upper)
+    private void ApplyJoint(HingeJoint2D joint, float lower, float upper, float speed)
     {
         if (joint == null)
             return;
@@ -37,6 +50,10 @@ public class LegJointLimiter : MonoBehaviour
         limits.max = upper;
         joint.limits = limits;
         joint.useLimits = true;
+        var motor = joint.motor;
+        motor.motorSpeed = speed;
+        joint.motor = motor;
+        joint.useMotor = true;
     }
 
     /// <summary>
@@ -46,6 +63,18 @@ public class LegJointLimiter : MonoBehaviour
     {
         leftLegJoint = FindJoint("LeftLowLeg");
         rightLegJoint = FindJoint("RightLowLeg");
+        CacheRightJoint();
+    }
+
+    private void CacheRightJoint()
+    {
+        if (rightLegJoint == null)
+            return;
+        var limits = rightLegJoint.limits;
+        minRight = limits.min;
+        maxRight = limits.max;
+        motorSpeedRight = rightLegJoint.motor.motorSpeed;
+        cached = true;
     }
 
     private HingeJoint2D FindJoint(string name)


### PR DESCRIPTION
## Summary
- cache right-leg hinge limits and motor speed
- mirror limits and motor speed when player flips facing
- update unit test to validate hinge mirroring

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: unity: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f34c894708324bb03893a1489ba90