### PR TITLE
Avoid scaling transforms for facing direction

### DIFF
--- a/Assets/Scripts/Player/Controllers/NewPlayerMovementController.cs
+++ b/Assets/Scripts/Player/Controllers/NewPlayerMovementController.cs
@@ -30,13 +30,17 @@ public sealed class NewPlayerMovementController : MonoBehaviour, ILookDirectionP
     private static readonly int GroundedParam = Animator.StringToHash("Grounded");
 
     private Vector2 lookDirection = Vector2.right;
+    /// <summary>
+    /// Current direction the character is facing.
+    /// </summary>
     public Vector2 LookDirection => lookDirection;
 
     public bool IsGrounded { get; private set; }
 
     [Header("Visual flip + poles")]
     [SerializeField] private SpriteRenderer[] sprites; // optional assign
-    [SerializeField] private PoleMirror2D poleMirror;  // optional
+    [SerializeField] private Transform visualRoot;      // optional scale target
+    [SerializeField] private PoleMirror2D poleMirror;   // optional
     [SerializeField] private LegJointLimiter legJointLimiter; // optional
 
     private bool facingLeft = false; // single source of truth
@@ -49,6 +53,11 @@ public sealed class NewPlayerMovementController : MonoBehaviour, ILookDirectionP
 
         if (sprites == null || sprites.Length == 0)
             sprites = GetComponentsInChildren<SpriteRenderer>(true);
+
+        if (transform.localScale != Vector3.one)
+            Debug.LogWarning("Root transform should have localScale == Vector3.one");
+        if (body && body.transform.localScale != Vector3.one)
+            Debug.LogWarning("Rigidbody parent should have localScale == Vector3.one");
     }
 
     private void Start()
@@ -105,9 +114,17 @@ public sealed class NewPlayerMovementController : MonoBehaviour, ILookDirectionP
         facingLeft = left;
 
         // visuals
-        if (sprites != null)
+        if (sprites != null && sprites.Length > 0)
+        {
             for (int i = 0; i < sprites.Length; i++)
                 if (sprites[i]) sprites[i].flipX = left;
+        }
+        else if (visualRoot)
+        {
+            var s = visualRoot.localScale;
+            s.x = left ? -Mathf.Abs(s.x) : Mathf.Abs(s.x);
+            visualRoot.localScale = s;
+        }
 
         // poles
         if (poleMirror) poleMirror.SetFacing(!left);              // expects isRight

--- a/Assets/Scripts/Robots/PoleMirror2D.cs
+++ b/Assets/Scripts/Robots/PoleMirror2D.cs
@@ -6,30 +6,30 @@ public sealed class PoleMirror2D : MonoBehaviour
     public struct Pole
     {
         public Transform target;    // pole Transform
-        public Vector3 localRight;  // right-facing local position (0 = auto-capture)
         public bool mirrorZRotation;
+        [HideInInspector] public float rightLocalX; // captured in Awake
     }
 
     [SerializeField] private Pole[] poles;
-    [SerializeField] private bool captureOnAwake = true;
     [SerializeField] private bool startFacingRight = true;
 
     private bool facingRight;
 
     private void Awake()
     {
-        if (captureOnAwake)
-        {
-            for (int i = 0; i < poles.Length; i++)
-                if (poles[i].target && poles[i].localRight == Vector3.zero)
-                    poles[i].localRight = poles[i].target.localPosition;
-        }
+        for (int i = 0; i < poles.Length; i++)
+            if (poles[i].target)
+                poles[i].rightLocalX = poles[i].target.localPosition.x;
 
         // Force an initial apply
         facingRight = !startFacingRight;
         SetFacing(startFacingRight);
     }
 
+    /// <summary>
+    /// Mirrors all poles to face the specified direction.
+    /// </summary>
+    /// <param name="isRight">True when facing right.</param>
     public void SetFacing(bool isRight)
     {
         if (facingRight == isRight) return;
@@ -40,9 +40,8 @@ public sealed class PoleMirror2D : MonoBehaviour
             var p = poles[i];
             if (!p.target) continue;
 
-            // mirror local X from the captured right pose
-            var pos = p.localRight;
-            if (!isRight) pos.x = -pos.x;
+            var pos = p.target.localPosition;
+            pos.x = isRight ? p.rightLocalX : -p.rightLocalX;
             p.target.localPosition = pos;
 
             if (p.mirrorZRotation)


### PR DESCRIPTION
## Summary
- Flip player by toggling SpriteRenderer `flipX` or scaling a visual-only child, leaving parents at unit scale
- Capture pole right-facing X at `Awake` and mirror only the X position when facing changes
- Warn if root or rigidbody parents have non-unit `localScale`

## Testing
- `bash setup_env.sh`
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: Package 'libasound2' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_689f34c57c748324b5a937e7404261d2