### PR TITLE
Fix orientation for body rotation limits

### DIFF
--- a/Assets/Scripts/Player/Controllers/PlayerMovementController.cs
+++ b/Assets/Scripts/Player/Controllers/PlayerMovementController.cs
@@ -94,11 +94,11 @@ public class PlayerMovementController : MonoBehaviour, ILookDirectionProvider
     private void ApplyFacingDirection()
     {
         locomotion.SetFacingDirection(!flipped);
-        legJointLimiter.SetLegRotationLimits(!flipped); // true = going left
+        legJointLimiter.SetLegRotationLimits(!flipped); // true = facing right
         if (bodyJointLimiter != null)
-            bodyJointLimiter.SetBodyRotationLimits(flipped);
+            bodyJointLimiter.SetBodyRotationLimits(!flipped);
 
-         // Mirror poles (arms, hands, etc.)
+        // Mirror poles (arms, hands, etc.)
         if (poleMirror != null)
             poleMirror.SetFacing(!flipped);
     }


### PR DESCRIPTION
## Summary
- Ensure body joint limiter receives facing-right state
- Clarify leg joint limiter comment

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a48dc0b6508324a0dbd5ee785efb3c