### PR TITLE
Refactor worker prefab to use NewEnemyWorkerController

### DIFF
--- a/Assets/Resources/Prefabs/Robots/Worker.prefab
+++ b/Assets/Resources/Prefabs/Robots/Worker.prefab
@@ -180,13 +180,12 @@ GameObject:
   - component: {fileID: 6178835051735462}
   - component: {fileID: 2375878962877187776}
   - component: {fileID: 340242974285803334}
-  - component: {fileID: 38189445005439173}
   - component: {fileID: 9201182588516880390}
   - component: {fileID: 8505160515933744807}
   - component: {fileID: 5579768388783519933}
   - component: {fileID: 574345331645963513}
   - component: {fileID: 6927027784846965603}
-  - component: {fileID: 1652121089499442319}
+  - component: {fileID: 8035967326927322595}
   - component: {fileID: 4920133160292708415}
   m_Layer: 7
   m_Name: Worker
@@ -315,36 +314,6 @@ MonoBehaviour:
     CurrentEnergy: 10
     AttackEnergyCost: 5
   hips: {fileID: 9206399112436540778}
---- !u!114 &38189445005439173
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9206399113533570876}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8118f832d5a89e8419977e547884cf70, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  moveSpeed: 3
-  animator: {fileID: 3831158568374747867}
-  bodyReference: {fileID: 9206399112436540782}
-  hipRb: {fileID: 9206399112436540778}
-  points: {fileID: 7353721863927515775}
-  poles: {fileID: 5653714254752795455}
-  legJointLimiter: {fileID: 6927027784846965603}
-  bodyJointLimiter: {fileID: 0}
-  stateMachine: {fileID: 9201182588516880390}
-  memoryComponent: {fileID: 8505160515933744807}
-  robotBehaviour: {fileID: 340242974285803334}
-  arrivalThresholdX: 0.5
-  arrivalThresholdY: 2
-  deadZoneX: 1
-  deadZoneY: 5
-  lowMoralityTriggerHandler: {fileID: 4920133160292708415}
-  allyWorkerController: {fileID: 1652121089499442319}
-  updateLoop: 0
 --- !u!114 &9201182588516880390
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -424,11 +393,11 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2fcdf7d50ffe16449b37f6ab3d1ab120, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   leftLegJoint: {fileID: 9206399113579118249}
   rightLegJoint: {fileID: 1967472705241727288}
---- !u!114 &1652121089499442319
+--- !u!114 &8035967326927322595
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -437,20 +406,17 @@ MonoBehaviour:
   m_GameObject: {fileID: 9206399113533570876}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 91c4743f29dfcbb42ab1d8ebd2a1caef, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Script: {fileID: 11500000, guid: 930bf15dd055481faf4689063271a077, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
   moveSpeed: 3
   animator: {fileID: 3831158568374747867}
   bodyReference: {fileID: 9206399112436540782}
   hipRb: {fileID: 9206399112436540778}
-  points: {fileID: 7353721863927515775}
-  poles: {fileID: 5653714254752795455}
   legJointLimiter: {fileID: 6927027784846965603}
-  bodyJointLimiter: {fileID: 0}
-  arrivalThresholdX: 2
+  arrivalThresholdX: 0.5
   arrivalThresholdY: 2
-  deadZoneX: 5
+  deadZoneX: 1
   deadZoneY: 5
   updateLoop: 0
 --- !u!114 &4920133160292708415


### PR DESCRIPTION
## Summary
- replace legacy worker controllers with NewEnemyWorkerController on Worker prefab

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a850b6a8e8832487b7e67de008e1ba