### PR TITLE
Remove unused waypoint notifier from EnemyWorkerController

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
@@ -25,8 +25,6 @@ public class EnemyWorkerController : AnimatorBaseAgentController
     [SerializeField] private float deadZoneX = 5f;
     [SerializeField] private float deadZoneY = 5f;
     [SerializeField] private UpdateLoop updateLoop = UpdateLoop.Update;
-
-    private IWaypointNotifier waypointNotifier;
     [SerializeField] private Inventory inventory;
     private BatteryPickup initialBattery;
     private BatterySpawner batterySpawner;


### PR DESCRIPTION
## Summary
- remove unused waypoint notifier field from `EnemyWorkerController`

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8649c248c83249f1b4fdf38f2f2cb