### PR TITLE
refactor: assign lift rigidbody via serialized field

### DIFF
--- a/Assets/Scripts/FactoryCore/LiftController.cs
+++ b/Assets/Scripts/FactoryCore/LiftController.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 
-[RequireComponent(typeof(MeshRenderer))]
-[RequireComponent(typeof(Rigidbody2D))]
 public class LiftController : MonoBehaviour
 {
     public enum LiftState { Idle, Warning, Moving }
@@ -12,6 +10,7 @@ public class LiftController : MonoBehaviour
     [Header("References")]
     public MeshRenderer lightRenderer;
     public Collider2D floorCollider;
+    public Rigidbody2D platformRb;
 
     [Header("Movement")]
     public Vector2 moveDirection = Vector2.up;
@@ -57,7 +56,12 @@ public class LiftController : MonoBehaviour
 
     private void Awake()
     {
-        rb = GetComponent<Rigidbody2D>();
+        rb = floorCollider ? floorCollider.attachedRigidbody : platformRb;
+        if (rb == null)
+        {
+            Debug.LogError("LiftController requires a Rigidbody2D reference.", this);
+            return;
+        }
         rb.isKinematic = true;
         startPos = rb.position;
         endPos = startPos + moveDirection.normalized * moveDistance;


### PR DESCRIPTION
## Summary
- decouple lift controller from required Rigidbody2D and MeshRenderer components
- add serialized `platformRb` reference and use floor collider's rigidbody if available
- initialize lift using provided rigidbody and error if missing

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a87dfa73688324b9b87a957f578d24