### PR TITLE
Use integer-based random selection for upgrade cubes

### DIFF
--- a/Assets/Scripts/Services/CubeSpawner.cs
+++ b/Assets/Scripts/Services/CubeSpawner.cs
@@ -5,7 +5,7 @@ public class CubeSpawner : MonoBehaviour
 {
     [SerializeField] private CubePickup normalCubePrefab;
     [SerializeField] private CubePickup[] upgradeCubePrefabs;
-    private Unity.Mathematics.Random _rnd = new Unity.Mathematics.Random((uint)Environment.TickCount);
+    private Unity.Mathematics.Random random = new Unity.Mathematics.Random((uint)Environment.TickCount);
 
 
     /// <summary>
@@ -32,8 +32,7 @@ public class CubeSpawner : MonoBehaviour
             return null;
         }
 
-
-        int index = (int)Math.Floor(_rnd.NextFloat(0f, upgradeCubePrefabs.Length));
+        int index = random.NextInt(0, upgradeCubePrefabs.Length);
         CubePickup prefab = upgradeCubePrefabs[index];
 
         return InstantiateCube(prefab, parent, position, parent.rotation);


### PR DESCRIPTION
## Summary
- rename `_rnd` to `random` in `CubeSpawner`
- use `Random.NextInt` instead of `Math.Floor(Random.NextFloat)` to select upgrade cubes without float conversion

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b026cf7cc48324be9c5cc734a497e4