### PR TITLE
Handle missing Rigidbody when spawning badges

### DIFF
--- a/Assets/Scripts/Services/SecurityBadgeSpawner.cs
+++ b/Assets/Scripts/Services/SecurityBadgeSpawner.cs
@@ -8,6 +8,9 @@ public class SecurityBadgeSpawner : MonoBehaviour
 {
     [SerializeField] private SecurityBadgePickup badgePrefab;
 
+    /// <summary>
+    /// Spawns a security badge and attaches it to the provided parent transform.
+    /// </summary>
     public SecurityBadgePickup SpawnBadge(Transform parent)
     {
         if (badgePrefab == null)
@@ -29,7 +32,8 @@ public class SecurityBadgeSpawner : MonoBehaviour
         if (badgeRb == null)
         {
             Debug.LogError("SecurityBadgeSpawner: badgePrefab needs a Rigidbody2D!");
-            return badge;
+            Destroy(badge.gameObject);
+            return null;
         }
 
         // // 3) Ensure the badge has a TargetJoint2D. If the prefab already


### PR DESCRIPTION
## Summary
- document `SpawnBadge` with an XML summary
- destroy and return null if the spawned badge lacks a `Rigidbody2D`

## Testing
- `unity -runTests -testPlatform EditMode -projectPath "$(pwd)" -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02aaf34a48324b617c383532ce707