### PR TITLE
Add shared robot decision interface for player and AI controllers

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -8,7 +8,7 @@ using System.Collections;
 /// and badge spawning services and provides APIs to change state or assign
 /// destinations.
 /// </summary>
-public class EnemyController : AnimatorBaseAgentController, IPooledObject
+public class EnemyController : AnimatorBaseAgentController, IPooledObject, IRobotDecisionProvider
 {
     [SerializeField] private EnemyStateMachine stateMachine;
     [SerializeField] private RobotMemory memoryComponent;
@@ -31,6 +31,7 @@ public class EnemyController : AnimatorBaseAgentController, IPooledObject
     public Transform BodyReference => bodyReference;
 
     [SerializeField] private EnemyPunchAttack punchAttack;
+    [SerializeField] private AttackRequestController attackRequestController;
     [SerializeField] private Inventory inventory;
 
     private FactoryAlarmStatus alarmStatus;
@@ -62,10 +63,20 @@ public class EnemyController : AnimatorBaseAgentController, IPooledObject
         if (robotBehaviour == null)
             robotBehaviour = GetComponent<RobotStateController>();
 
+        if (punchAttack == null)
+            punchAttack = GetComponent<EnemyPunchAttack>();
+
         robotBehaviour.OnStateChanged += HandleStateChange;
 
         if (inventory == null)
             inventory = GetComponent<Inventory>();
+
+        if (attackRequestController == null)
+        {
+            attackRequestController = GetComponent<AttackRequestController>();
+            if (attackRequestController == null)
+                attackRequestController = GetComponentInChildren<AttackRequestController>();
+        }
     }
 
     public void Initialize(
@@ -151,6 +162,8 @@ public class EnemyController : AnimatorBaseAgentController, IPooledObject
         TryFlip(direction);
         if (updateLoop == UpdateLoop.Update)
             pathFollower?.Update(Time.deltaTime);
+
+        ProcessAttackDecisions();
     }
 
     protected override void FixedUpdate()
@@ -159,6 +172,31 @@ public class EnemyController : AnimatorBaseAgentController, IPooledObject
         base.FixedUpdate();
         if (updateLoop == UpdateLoop.FixedUpdate)
             pathFollower?.Update(Time.fixedDeltaTime);
+    }
+
+    /// <inheritdoc />
+    public Vector2 Movement => new Vector2(direction, verticalDirection);
+
+    /// <inheritdoc />
+    public Vector2 DesiredFacing => LookDirection;
+
+    /// <inheritdoc />
+    public bool TryBuildAttackRequest(out AttackRequest request)
+    {
+        if (punchAttack != null && punchAttack.TryBuildAttackRequest(out request))
+            return true;
+
+        request = default;
+        return false;
+    }
+
+    private void ProcessAttackDecisions()
+    {
+        if (attackRequestController == null)
+            return;
+
+        if (TryBuildAttackRequest(out AttackRequest request))
+            attackRequestController.TryHandleAttack(request);
     }
 
 

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyPunchAttack.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyPunchAttack.cs
@@ -13,7 +13,6 @@ public sealed class EnemyPunchAttack : MonoBehaviour
     [SerializeField] private FactoryAlarmStatus alarmStatus;
 
     private RobotStateController robotBehaviour;
-    private AttackRequestController attackRequestController;
     private RobotStats playerStats;
     private float lastPunchTime;
     private bool playerInAttackZone;
@@ -21,12 +20,6 @@ public sealed class EnemyPunchAttack : MonoBehaviour
     private void Awake()
     {
         robotBehaviour = GetComponent<RobotStateController>();
-        attackRequestController = GetComponent<AttackRequestController>();
-        if (attackRequestController == null)
-        {
-            attackRequestController = GetComponentInChildren<AttackRequestController>();
-        }
-
         if (alarmStatus == null)
         {
             alarmStatus = FindFirstObjectByType<FactoryManager>()?.factoryAlarmStatus;
@@ -64,22 +57,24 @@ public sealed class EnemyPunchAttack : MonoBehaviour
         playerInAttackZone = isInside;
     }
 
-    private void Update()
+    public bool TryBuildAttackRequest(out AttackRequest request)
     {
+        request = default;
+
         if (!CanIssueAttack())
         {
-            return;
+            return false;
         }
 
         Vector3 playerPosition = targetToFollow.PlayerBodyReferencePosition;
         if (playerPosition == Vector3.zero)
         {
-            return;
+            return false;
         }
 
         if (Time.time < lastPunchTime + attackCooldown)
         {
-            return;
+            return false;
         }
 
         AttackSector sector = ResolveSector(playerPosition);
@@ -88,16 +83,14 @@ public sealed class EnemyPunchAttack : MonoBehaviour
             : 0f;
 
         Vector2 targetPosition = new Vector2(playerPosition.x, playerPosition.y);
-        AttackRequest request = new AttackRequest(targetPosition, sector, energyCost);
-        if (attackRequestController != null && attackRequestController.TryHandleAttack(request))
-        {
-            lastPunchTime = Time.time;
-        }
+        request = new AttackRequest(targetPosition, sector, energyCost);
+        lastPunchTime = Time.time;
+        return true;
     }
 
     private bool CanIssueAttack()
     {
-        if (attackRequestController == null || targetToFollow == null || !playerInAttackZone)
+        if (targetToFollow == null || !playerInAttackZone)
         {
             return false;
         }

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyWorkerController.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 /// Controls enemy worker navigation using waypoint-based pathing.
 /// </summary>
 [RequireComponent(typeof(WorkerStateMachine), typeof(RobotMemory))]
-public class EnemyWorkerController : AnimatorBaseAgentController
+public class EnemyWorkerController : AnimatorBaseAgentController, IRobotDecisionProvider
 {
     [SerializeField] public WorkerStateMachine stateMachine;
     [SerializeField] private RobotMemory memoryComponent;
@@ -111,6 +111,19 @@ public class EnemyWorkerController : AnimatorBaseAgentController
         base.FixedUpdate();
         if (updateLoop == UpdateLoop.FixedUpdate)
             pathFollower?.Update(Time.fixedDeltaTime);
+    }
+
+    /// <inheritdoc />
+    public Vector2 Movement => new Vector2(direction, verticalDirection);
+
+    /// <inheritdoc />
+    public Vector2 DesiredFacing => LookDirection;
+
+    /// <inheritdoc />
+    public bool TryBuildAttackRequest(out AttackRequest request)
+    {
+        request = default;
+        return false;
     }
 
     private void SetupPathFollower()

--- a/Assets/Scripts/Player/Controllers/PlayerAttackController.cs
+++ b/Assets/Scripts/Player/Controllers/PlayerAttackController.cs
@@ -1,56 +1,26 @@
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.InputSystem;
 
 public class PlayerAttackController : MonoBehaviour
 {
     public List<Attack> Attacks { get; private set; } = new List<Attack>();
 
     [SerializeField] private PlayerMovementController movementController;
-    [SerializeField] private RobotStateController robotStateController;
-
-    private InputSystem_Actions controls;
-    private bool attackHeld;
-    private AttackSector currentSector = AttackSector.Right;
+    private IRobotDecisionProvider decisionProvider;
 
     private void Awake()
     {
-        controls = new InputSystem_Actions();
-        controls.Player.Attack.started += _ => attackHeld = true;
-        controls.Player.Attack.canceled += _ => attackHeld = false;
-
         if (movementController == null)
             movementController = GetComponent<PlayerMovementController>();
 
         if (movementController != null)
-        {
-            currentSector = movementController.CurrentSector;
-            movementController.SectorChanged += HandleSectorChanged;
-        }
+            decisionProvider = movementController;
 
-        if (robotStateController == null)
-            robotStateController = GetComponent<RobotStateController>();
-    }
+        if (decisionProvider == null)
+            decisionProvider = GetComponent<IRobotDecisionProvider>();
 
-    private void OnDestroy()
-    {
-        if (movementController != null)
-            movementController.SectorChanged -= HandleSectorChanged;
-
-        controls?.Dispose();
-    }
-
-    private void HandleSectorChanged(AttackSector sector)
-    {
-        currentSector = sector;
-    }
-
-    private void OnEnable() => controls.Enable();
-
-    private void OnDisable()
-    {
-        controls.Disable();
-        attackHeld = false;
+        if (decisionProvider == null)
+            Debug.LogError("PlayerAttackController requires an IRobotDecisionProvider.");
     }
 
     public void InitializeAttacks(List<Attack> attacks)
@@ -60,36 +30,10 @@ public class PlayerAttackController : MonoBehaviour
 
     private void Update()
     {
-        if (!attackHeld || Attacks.Count == 0)
+        if (decisionProvider == null || Attacks.Count == 0)
             return;
 
-        AttackRequest request = BuildRequest();
-        Attacks[0].Execute(request);
-    }
-
-    private AttackRequest BuildRequest()
-    {
-        Vector2 targetPosition = DetermineTargetPosition();
-        float energyRequired = 0f;
-
-        if (robotStateController != null && robotStateController.Stats != null)
-            energyRequired = robotStateController.Stats.AttackEnergyCost;
-
-        return new AttackRequest(targetPosition, currentSector, energyRequired);
-    }
-
-    private Vector2 DetermineTargetPosition()
-    {
-        if (movementController != null)
-        {
-            Vector2 aim = movementController.AimVector;
-            if (aim.sqrMagnitude <= 0.0001f)
-                aim = movementController.LookDirection;
-
-            if (aim.sqrMagnitude > 0.0001f)
-                return (Vector2)transform.position + aim.normalized;
-        }
-
-        return transform.position;
+        if (decisionProvider.TryBuildAttackRequest(out AttackRequest request))
+            Attacks[0].Execute(request);
     }
 }

--- a/Assets/Scripts/Player/Controllers/PlayerMovementController.cs
+++ b/Assets/Scripts/Player/Controllers/PlayerMovementController.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine;
 
 [RequireComponent(typeof(RobotLocomotionController), typeof(Inventory))]
-public class PlayerMovementController : MonoBehaviour, ILookDirectionProvider
+public class PlayerMovementController : MonoBehaviour, ILookDirectionProvider, IRobotDecisionProvider
 {
     [Header("Components")]
     [SerializeField] private RobotLocomotionController locomotion;
@@ -41,6 +41,7 @@ public class PlayerMovementController : MonoBehaviour, ILookDirectionProvider
     private Vector2 aimVector = Vector2.right;
     private bool aimFromLookInput = false;
     private AttackSector currentSector = AttackSector.Right;
+
 
     /// <summary>
     /// Invoked when the attack sector changes based on input.
@@ -90,6 +91,7 @@ public class PlayerMovementController : MonoBehaviour, ILookDirectionProvider
         {
             horizontalInput = input.Movement.x;
             verticalInput = input.Movement.y;
+
 
             if (Mathf.Abs(horizontalInput) > 0.1f)
                 lookDirection = new Vector2(Mathf.Sign(horizontalInput), 0f);
@@ -202,6 +204,54 @@ public class PlayerMovementController : MonoBehaviour, ILookDirectionProvider
         }
 
         isCrouchingInput = verticalInput < 0;
+    }
+
+    /// <inheritdoc />
+    public Vector2 Movement => new Vector2(horizontalInput, verticalInput);
+
+    /// <inheritdoc />
+    public Vector2 DesiredFacing
+    {
+        get
+        {
+            if (aimVector.sqrMagnitude > 0.0001f)
+                return aimVector.normalized;
+            if (lookDirection.sqrMagnitude > 0.0001f)
+                return lookDirection.normalized;
+            return Vector2.right;
+        }
+    }
+
+    /// <inheritdoc />
+    public bool TryBuildAttackRequest(out AttackRequest request)
+    {
+        request = default;
+
+        if (input == null || !input.PrimaryAttack || robotBehaviour == null)
+            return false;
+
+        if (robotBehaviour.CurrentState != RobotState.Alive)
+            return false;
+
+        float energyRequired = 0f;
+        if (robotBehaviour.Stats != null)
+            energyRequired = robotBehaviour.Stats.AttackEnergyCost;
+
+        Vector2 targetPosition = DetermineTargetPosition();
+        request = new AttackRequest(targetPosition, currentSector, energyRequired);
+        return true;
+    }
+
+    private Vector2 DetermineTargetPosition()
+    {
+        Vector2 aim = aimVector;
+        if (aim.sqrMagnitude <= 0.0001f)
+            aim = lookDirection;
+
+        if (aim.sqrMagnitude > 0.0001f)
+            return (Vector2)transform.position + aim.normalized;
+
+        return transform.position;
     }
 
     private void UpdateAttackSector()

--- a/Assets/Scripts/Robots/Decisions.meta
+++ b/Assets/Scripts/Robots/Decisions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 65ccfdadf110427b8388b0d586218177
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Robots/Decisions/IRobotDecisionProvider.cs
+++ b/Assets/Scripts/Robots/Decisions/IRobotDecisionProvider.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+
+/// <summary>
+/// Provides high-level decision data for a robot including how it wishes to move,
+/// face, and whether it wants to execute an attack.
+/// </summary>
+public interface IRobotDecisionProvider
+{
+    /// <summary>
+    /// Gets the desired movement input, typically ranging from -1 to 1 per axis.
+    /// </summary>
+    Vector2 Movement { get; }
+
+    /// <summary>
+    /// Gets the desired facing direction for aiming and mirroring purposes.
+    /// </summary>
+    Vector2 DesiredFacing { get; }
+
+    /// <summary>
+    /// Attempts to build an attack request for the current frame.
+    /// </summary>
+    /// <param name="request">Request describing the desired attack.</param>
+    /// <returns><c>true</c> when an attack should be executed.</returns>
+    bool TryBuildAttackRequest(out AttackRequest request);
+}

--- a/Assets/Scripts/Robots/Decisions/IRobotDecisionProvider.cs.meta
+++ b/Assets/Scripts/Robots/Decisions/IRobotDecisionProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 99a72732edd24c1ea297ffd7b7a17245


### PR DESCRIPTION
## Summary
- add an IRobotDecisionProvider interface to expose movement, facing, and attack requests
- adapt the player movement and attack controllers to supply attack requests through the interface
- refactor enemy controllers and punch attack logic to consume the shared decision interface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6909a108700c832497dc016c76fc1305