### PR TITLE
Prevent repeated attack energy consumption

### DIFF
--- a/Assets/Editor/UnitTests/AttackRequestControllerTests.cs
+++ b/Assets/Editor/UnitTests/AttackRequestControllerTests.cs
@@ -1,0 +1,40 @@
+using NUnit.Framework;
+using UnityEngine;
+
+public class AttackRequestControllerTests
+{
+    [Test]
+    public void HeldAttackConsumesEnergyOnce()
+    {
+        var robot = new GameObject("Robot");
+        var energyBot = robot.AddComponent<EnergyBot>();
+        var stateController = robot.AddComponent<RobotStateController>();
+        stateController.Stats = new RobotStats
+        {
+            MaxEnergy = 10f,
+            CurrentEnergy = 10f,
+            AttackEnergyCost = 2f
+        };
+
+        robot.AddComponent<PlayerPunchAnimator>();
+        var controller = robot.AddComponent<AttackRequestController>();
+
+        var request = new AttackRequest(Vector2.zero, AttackSector.Right, 0f);
+
+        bool firstAccepted = controller.TryHandleAttack(request);
+        Assert.IsTrue(firstAccepted);
+        Assert.AreEqual(8f, stateController.Stats.CurrentEnergy);
+
+        bool secondAccepted = controller.TryHandleAttack(request);
+        Assert.IsFalse(secondAccepted);
+        Assert.AreEqual(8f, stateController.Stats.CurrentEnergy);
+
+        controller.NotifyPunchCompleted();
+
+        bool thirdAccepted = controller.TryHandleAttack(request);
+        Assert.IsTrue(thirdAccepted);
+        Assert.AreEqual(6f, stateController.Stats.CurrentEnergy);
+
+        Object.DestroyImmediate(robot);
+    }
+}

--- a/Assets/Editor/UnitTests/AttackRequestControllerTests.cs.meta
+++ b/Assets/Editor/UnitTests/AttackRequestControllerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b28050ccd0d2424d82379743a5835ee3

--- a/Assets/Scripts/Combat/AttackRequestController.cs
+++ b/Assets/Scripts/Combat/AttackRequestController.cs
@@ -21,6 +21,7 @@ public sealed class AttackRequestController : MonoBehaviour
     private int punchDirectionHash;
     private int punchTriggerHash;
     private bool hashesInitialized;
+    private bool attackInProgress;
 
     private void Awake()
     {
@@ -36,6 +37,11 @@ public sealed class AttackRequestController : MonoBehaviour
             {
                 punchAnimator = GetComponentInChildren<PlayerPunchAnimator>();
             }
+        }
+
+        if (punchAnimator != null)
+        {
+            punchAnimator.PunchCompleted += NotifyPunchCompleted;
         }
 
         if (hitboxRelay == null)
@@ -64,6 +70,19 @@ public sealed class AttackRequestController : MonoBehaviour
         }
     }
 
+    private void OnDestroy()
+    {
+        if (punchAnimator != null)
+        {
+            punchAnimator.PunchCompleted -= NotifyPunchCompleted;
+        }
+    }
+
+    private void OnDisable()
+    {
+        attackInProgress = false;
+    }
+
     /// <summary>
     /// Attempts to execute the provided <paramref name="request"/> on the robot.
     /// </summary>
@@ -71,6 +90,16 @@ public sealed class AttackRequestController : MonoBehaviour
     /// <returns>True when the request was accepted.</returns>
     public bool TryHandleAttack(AttackRequest request)
     {
+        if (attackInProgress)
+        {
+            return false;
+        }
+
+        if (!CanTriggerAnimation())
+        {
+            return false;
+        }
+
         if (!ConsumeEnergy(request))
         {
             hitboxRelay?.ForceDeactivateAllHitboxes();
@@ -79,6 +108,7 @@ public sealed class AttackRequestController : MonoBehaviour
         }
 
         TriggerAnimation(request);
+        attackInProgress = true;
         return true;
     }
 
@@ -102,6 +132,7 @@ public sealed class AttackRequestController : MonoBehaviour
         {
             punchAnimator.AbortActivePunch();
             hitboxRelay?.ForceDeactivateAllHitboxes();
+            attackInProgress = false;
             return;
         }
 
@@ -112,6 +143,15 @@ public sealed class AttackRequestController : MonoBehaviour
         }
 
         hitboxRelay?.ForceDeactivateAllHitboxes();
+        attackInProgress = false;
+    }
+
+    /// <summary>
+    /// Clears the active attack flag when the punch animation completes.
+    /// </summary>
+    public void NotifyPunchCompleted()
+    {
+        attackInProgress = false;
     }
 
     private bool ConsumeEnergy(AttackRequest request)
@@ -133,6 +173,16 @@ public sealed class AttackRequestController : MonoBehaviour
         }
 
         return robotStateController.PerformAttackByEnergy(requiredEnergy);
+    }
+
+    private bool CanTriggerAnimation()
+    {
+        if (punchAnimator != null)
+        {
+            return true;
+        }
+
+        return animator != null && hashesInitialized;
     }
 
     private void TriggerAnimation(AttackRequest request)

--- a/Assets/Scripts/Player/Controllers/PlayerPunchAnimator.cs
+++ b/Assets/Scripts/Player/Controllers/PlayerPunchAnimator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using UnityEngine;
 
@@ -26,6 +27,8 @@ public sealed class PlayerPunchAnimator : MonoBehaviour
     private int punchTriggerHash;
     private Coroutine punchRoutine;
     private AttackSector currentAttackSector = AttackSector.Right;
+
+    public event Action PunchCompleted;
 
     private void Awake()
     {
@@ -116,6 +119,7 @@ public sealed class PlayerPunchAnimator : MonoBehaviour
         animator.ResetTrigger(punchTriggerHash);
         animator.SetInteger(punchDirectionHash, idleDirectionValue);
         currentAttackSector = AttackSector.Right;
+        PunchCompleted?.Invoke();
     }
 
     private IEnumerator ResetPunchAfterCompletion()
@@ -147,6 +151,7 @@ public sealed class PlayerPunchAnimator : MonoBehaviour
         animator.SetInteger(punchDirectionHash, idleDirectionValue);
         punchRoutine = null;
         currentAttackSector = AttackSector.Right;
+        PunchCompleted?.Invoke();
     }
 
     private void OnDisable()
@@ -164,5 +169,6 @@ public sealed class PlayerPunchAnimator : MonoBehaviour
         }
 
         currentAttackSector = AttackSector.Right;
+        PunchCompleted?.Invoke();
     }
 }


### PR DESCRIPTION
## Summary
- add attack state tracking in AttackRequestController so energy is only consumed when a punch starts
- emit punch completion events from PlayerPunchAnimator to release attack gating after animations finish
- cover held-attack behaviour with a new unit test that verifies energy drains once per punch

## Testing
- not run (Unity CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6909e94891388324b582c6abfd6756f5