### PR TITLE
Ensure punch hitboxes deactivate on aborted attacks

### DIFF
--- a/Assets/Editor/UnitTests/PunchHitboxEventRelayTests.cs
+++ b/Assets/Editor/UnitTests/PunchHitboxEventRelayTests.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public class PunchHitboxEventRelayTests
+{
+    [Test]
+    public void ForceDeactivatesHitboxesWhenAttackAborts()
+    {
+        var root = new GameObject("Robot");
+        var attackController = root.AddComponent<AttackRequestController>();
+        var relay = root.AddComponent<PunchHitboxEventRelay>();
+
+        var hitboxObject = new GameObject("LeftHitbox");
+        hitboxObject.transform.SetParent(root.transform);
+        var leftHitbox = hitboxObject.AddComponent<AttackHitbox>();
+
+        SetPrivateField(relay, "leftArmHitbox", leftHitbox);
+
+        leftHitbox.Activate();
+
+        LogAssert.Expect(LogType.Warning, "[PunchHitboxEventRelay] Hitbox 'LeftHitbox' remained active during forced deactivation.");
+
+        attackController.AbortActiveAttack();
+
+        Assert.IsFalse(leftHitbox.IsActive, "Hitbox should be inactive after abort.");
+
+        Object.DestroyImmediate(root);
+    }
+
+    private static void SetPrivateField(object target, string fieldName, object value)
+    {
+        FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.IsNotNull(field, $"Field '{fieldName}' not found on {target.GetType()}.");
+        field.SetValue(target, value);
+    }
+}

--- a/Assets/Scripts/Combat/AttackRequestController.cs
+++ b/Assets/Scripts/Combat/AttackRequestController.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 /// <summary>
@@ -22,6 +23,11 @@ public sealed class AttackRequestController : MonoBehaviour
     private int punchTriggerHash;
     private bool hashesInitialized;
     private bool attackInProgress;
+
+    /// <summary>
+    /// Raised whenever an active punch is aborted or cancelled.
+    /// </summary>
+    public event Action AttackAborted;
 
     private void Awake()
     {
@@ -81,6 +87,8 @@ public sealed class AttackRequestController : MonoBehaviour
     private void OnDisable()
     {
         attackInProgress = false;
+        hitboxRelay?.ForceDeactivateAllHitboxes();
+        AttackAborted?.Invoke();
     }
 
     /// <summary>
@@ -131,12 +139,8 @@ public sealed class AttackRequestController : MonoBehaviour
         if (punchAnimator != null)
         {
             punchAnimator.AbortActivePunch();
-            hitboxRelay?.ForceDeactivateAllHitboxes();
-            attackInProgress = false;
-            return;
         }
-
-        if (animator != null && hashesInitialized)
+        else if (animator != null && hashesInitialized)
         {
             animator.ResetTrigger(punchTriggerHash);
             animator.SetInteger(punchDirectionHash, idleDirectionValue);
@@ -144,6 +148,7 @@ public sealed class AttackRequestController : MonoBehaviour
 
         hitboxRelay?.ForceDeactivateAllHitboxes();
         attackInProgress = false;
+        AttackAborted?.Invoke();
     }
 
     /// <summary>

--- a/Assets/Scripts/Player/Controllers/PunchHitboxEventRelay.cs
+++ b/Assets/Scripts/Player/Controllers/PunchHitboxEventRelay.cs
@@ -15,6 +15,7 @@ public sealed class PunchHitboxEventRelay : MonoBehaviour
     [Header("Dependencies")]
     [SerializeField] private RobotStateController robotStateController;
     [SerializeField] private PlayerPunchAnimator punchAnimator;
+    [SerializeField] private AttackRequestController attackRequestController;
 
     private void Awake()
     {
@@ -30,6 +31,46 @@ public sealed class PunchHitboxEventRelay : MonoBehaviour
             {
                 punchAnimator = GetComponentInChildren<PlayerPunchAnimator>();
             }
+        }
+
+        if (attackRequestController == null)
+        {
+            attackRequestController = GetComponent<AttackRequestController>();
+            if (attackRequestController == null)
+            {
+                attackRequestController = GetComponentInParent<AttackRequestController>();
+            }
+        }
+    }
+
+    private void OnEnable()
+    {
+        if (punchAnimator == null)
+        {
+            punchAnimator = GetComponent<PlayerPunchAnimator>();
+            if (punchAnimator == null)
+            {
+                punchAnimator = GetComponentInChildren<PlayerPunchAnimator>();
+            }
+        }
+
+        if (punchAnimator != null)
+        {
+            punchAnimator.PunchCompleted += HandlePunchCompleted;
+        }
+
+        if (attackRequestController == null)
+        {
+            attackRequestController = GetComponent<AttackRequestController>();
+            if (attackRequestController == null)
+            {
+                attackRequestController = GetComponentInParent<AttackRequestController>();
+            }
+        }
+
+        if (attackRequestController != null)
+        {
+            attackRequestController.AttackAborted += HandleAttackAborted;
         }
     }
 
@@ -169,11 +210,48 @@ public sealed class PunchHitboxEventRelay : MonoBehaviour
     /// </summary>
     public void ForceDeactivateAllHitboxes()
     {
+        LogActiveHitboxes();
         DeactivateAllHitboxes();
     }
 
     private void OnDisable()
     {
+        if (punchAnimator != null)
+        {
+            punchAnimator.PunchCompleted -= HandlePunchCompleted;
+        }
+
+        if (attackRequestController != null)
+        {
+            attackRequestController.AttackAborted -= HandleAttackAborted;
+        }
+
         DeactivateAllHitboxes();
+    }
+
+    private void HandleAttackAborted()
+    {
+        ForceDeactivateAllHitboxes();
+    }
+
+    private void HandlePunchCompleted()
+    {
+        ForceDeactivateAllHitboxes();
+    }
+
+    private void LogActiveHitboxes()
+    {
+        LogHitboxIfActive(leftArmHitbox);
+        LogHitboxIfActive(rightArmHitbox);
+        LogHitboxIfActive(upHitbox);
+        LogHitboxIfActive(downHitbox);
+    }
+
+    private void LogHitboxIfActive(AttackHitbox hitbox)
+    {
+        if (hitbox != null && hitbox.IsActive)
+        {
+            Debug.LogWarning($"[PunchHitboxEventRelay] Hitbox '{hitbox.name}' remained active during forced deactivation.");
+        }
     }
 }

--- a/Assets/Scripts/Robots/AttackHitbox.cs
+++ b/Assets/Scripts/Robots/AttackHitbox.cs
@@ -17,6 +17,11 @@ public class AttackHitbox : MonoBehaviour
     public void Activate() => isActive = true;
     public void Deactivate() => isActive = false;
 
+    /// <summary>
+    /// Indicates whether the hitbox is currently active.
+    /// </summary>
+    public bool IsActive => isActive;
+
     private void OnTriggerEnter2D(Collider2D other)
     {
         if (!isActive) return;


### PR DESCRIPTION
## Summary
- add an `AttackAborted` event to `AttackRequestController` and invoke it whenever punches are cancelled or the controller is disabled
- subscribe `PunchHitboxEventRelay` to punch completion/abort callbacks so all hitboxes are forcefully deactivated and log any stragglers
- expose the active state on `AttackHitbox` and add an edit mode test that verifies hitboxes are shut off (and warnings issued) after an abort

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6909eee5bec48324a10514750a343854