### PR TITLE
Align punch animations with attack targets

### DIFF
--- a/Assets/Scripts/Combat/AttackRequestController.cs
+++ b/Assets/Scripts/Combat/AttackRequestController.cs
@@ -13,15 +13,22 @@ public sealed class AttackRequestController : MonoBehaviour
     [SerializeField] private PlayerPunchAnimator punchAnimator;
     [SerializeField] private PunchHitboxEventRelay hitboxRelay;
     [SerializeField] private Animator animator;
+    [SerializeField] private Transform aimOrigin;
 
     [Header("Animator Parameters")]
     [SerializeField] private string punchDirectionParameter = "PunchDirection";
     [SerializeField] private string punchTriggerParameter = "PunchTrigger";
+    [SerializeField] private string punchAimXParameter = "PunchAimX";
+    [SerializeField] private string punchAimYParameter = "PunchAimY";
     [SerializeField] private int idleDirectionValue = -1;
 
     private int punchDirectionHash;
     private int punchTriggerHash;
+    private int punchAimXHash;
+    private int punchAimYHash;
     private bool hashesInitialized;
+    private bool hasPunchAimXParameter;
+    private bool hasPunchAimYParameter;
     private bool attackInProgress;
 
     /// <summary>
@@ -68,11 +75,19 @@ public sealed class AttackRequestController : MonoBehaviour
             }
         }
 
+        if (aimOrigin == null)
+        {
+            aimOrigin = transform;
+        }
+
         if (animator != null)
         {
             punchDirectionHash = Animator.StringToHash(punchDirectionParameter);
             punchTriggerHash = Animator.StringToHash(punchTriggerParameter);
+            hasPunchAimXParameter = TryResolveFloatParameter(punchAimXParameter, out punchAimXHash);
+            hasPunchAimYParameter = TryResolveFloatParameter(punchAimYParameter, out punchAimYHash);
             hashesInitialized = true;
+            ResetAimParameters();
         }
     }
 
@@ -89,6 +104,10 @@ public sealed class AttackRequestController : MonoBehaviour
         attackInProgress = false;
         hitboxRelay?.ForceDeactivateAllHitboxes();
         AttackAborted?.Invoke();
+        if (punchAnimator == null)
+        {
+            ResetAimParameters();
+        }
     }
 
     /// <summary>
@@ -143,7 +162,7 @@ public sealed class AttackRequestController : MonoBehaviour
         else if (animator != null && hashesInitialized)
         {
             animator.ResetTrigger(punchTriggerHash);
-            animator.SetInteger(punchDirectionHash, idleDirectionValue);
+            ResetAimParameters();
         }
 
         hitboxRelay?.ForceDeactivateAllHitboxes();
@@ -203,10 +222,124 @@ public sealed class AttackRequestController : MonoBehaviour
             return;
         }
 
+        Vector2 aimDirection = ResolveAimDirection(request);
+        ApplyAimParameters(aimDirection);
+
         int directionValue = ResolveDirection(request.Sector);
         animator.SetInteger(punchDirectionHash, directionValue);
         animator.ResetTrigger(punchTriggerHash);
         animator.SetTrigger(punchTriggerHash);
+    }
+
+    private Vector2 ResolveAimDirection(AttackRequest request)
+    {
+        Vector2 origin = aimOrigin != null ? (Vector2)aimOrigin.position : (Vector2)transform.position;
+        Vector2 delta = request.TargetPosition - origin;
+
+        if (delta.sqrMagnitude > 0.0001f)
+        {
+            return delta.normalized;
+        }
+
+        return ResolveFallbackDirection(request.Sector);
+    }
+
+    private Vector2 ResolveFallbackDirection(AttackSector sector)
+    {
+        switch (sector)
+        {
+            case AttackSector.Up:
+                return Vector2.up;
+            case AttackSector.Down:
+                return Vector2.down;
+            case AttackSector.Left:
+                return Vector2.left;
+            case AttackSector.Right:
+            default:
+                return Vector2.right;
+        }
+    }
+
+    private Vector2 ResolveDefaultAimDirection()
+    {
+        if (punchAnimator != null)
+        {
+            return punchAnimator.IsCurrentlyFacingRight ? Vector2.right : Vector2.left;
+        }
+
+        float scaleX = transform != null ? transform.lossyScale.x : 1f;
+        if (Mathf.Approximately(scaleX, 0f))
+        {
+            return Vector2.right;
+        }
+
+        return scaleX >= 0f ? Vector2.right : Vector2.left;
+    }
+
+    private void ApplyAimParameters(Vector2 aimDirection)
+    {
+        if (aimDirection.sqrMagnitude <= 0.0001f)
+        {
+            aimDirection = ResolveDefaultAimDirection();
+        }
+
+        if (animator != null)
+        {
+            if (hasPunchAimXParameter)
+            {
+                animator.SetFloat(punchAimXHash, aimDirection.x);
+            }
+
+            if (hasPunchAimYParameter)
+            {
+                animator.SetFloat(punchAimYHash, aimDirection.y);
+            }
+        }
+    }
+
+    private void ResetAimParameters()
+    {
+        if (animator == null || !hashesInitialized)
+        {
+            return;
+        }
+
+        Vector2 resolvedDefault = ResolveDefaultAimDirection();
+
+        if (hasPunchAimXParameter)
+        {
+            animator.SetFloat(punchAimXHash, resolvedDefault.x);
+        }
+
+        if (hasPunchAimYParameter)
+        {
+            animator.SetFloat(punchAimYHash, resolvedDefault.y);
+        }
+
+        animator.SetInteger(punchDirectionHash, idleDirectionValue);
+    }
+
+    private bool TryResolveFloatParameter(string parameterName, out int hash)
+    {
+        hash = 0;
+        if (animator == null || string.IsNullOrEmpty(parameterName))
+        {
+            return false;
+        }
+
+        AnimatorControllerParameter[] parameters = animator.parameters;
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            AnimatorControllerParameter parameter = parameters[i];
+            if (parameter.type == AnimatorControllerParameterType.Float &&
+                string.Equals(parameter.name, parameterName, StringComparison.Ordinal))
+            {
+                hash = Animator.StringToHash(parameterName);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private int ResolveDirection(AttackSector sector)

--- a/Assets/Scripts/Player/Controllers/PlayerPunchAnimator.cs
+++ b/Assets/Scripts/Player/Controllers/PlayerPunchAnimator.cs
@@ -11,8 +11,12 @@ public sealed class PlayerPunchAnimator : MonoBehaviour
 {
     [SerializeField] private Animator animator;
     [SerializeField] private PlayerMovementController movementController;
+    [SerializeField] private Transform aimOrigin;
+    [SerializeField] private Transform masterRigRoot;
     [SerializeField] private string punchDirectionParameter = "PunchDirection";
     [SerializeField] private string punchTriggerParameter = "PunchTrigger";
+    [SerializeField] private string punchAimXParameter = "PunchAimX";
+    [SerializeField] private string punchAimYParameter = "PunchAimY";
     [SerializeField] private int idleDirectionValue = -1;
     [SerializeField] private int punchLayerIndex = 0;
 
@@ -25,8 +29,13 @@ public sealed class PlayerPunchAnimator : MonoBehaviour
 
     private int punchDirectionHash;
     private int punchTriggerHash;
+    private int punchAimXHash;
+    private int punchAimYHash;
+    private bool hasPunchAimXParameter;
+    private bool hasPunchAimYParameter;
     private Coroutine punchRoutine;
     private AttackSector currentAttackSector = AttackSector.Right;
+    private Quaternion masterRigBaseLocalRotation;
 
     public event Action PunchCompleted;
 
@@ -42,9 +51,23 @@ public sealed class PlayerPunchAnimator : MonoBehaviour
             movementController = GetComponent<PlayerMovementController>();
         }
 
-        punchDirectionHash = Animator.StringToHash(punchDirectionParameter);
-        punchTriggerHash = Animator.StringToHash(punchTriggerParameter);
-        animator?.SetInteger(punchDirectionHash, idleDirectionValue);
+        if (aimOrigin == null)
+        {
+            aimOrigin = transform;
+        }
+
+        if (masterRigRoot != null)
+        {
+            masterRigBaseLocalRotation = masterRigRoot.localRotation;
+        }
+
+        CacheAnimatorParameters();
+        ResetAimState();
+    }
+
+    private void OnEnable()
+    {
+        ResetAimState();
     }
 
     /// <summary>
@@ -53,8 +76,12 @@ public sealed class PlayerPunchAnimator : MonoBehaviour
     /// <param name="request">The attack request emitted by the player attack controller.</param>
     public void HandleAttackRequest(AttackRequest request)
     {
+        Vector2 aimDirection = ResolveAimDirection(request);
+        ApplyAimDirection(aimDirection);
+
         if (animator == null)
         {
+            currentAttackSector = request.Sector;
             return;
         }
 
@@ -99,6 +126,118 @@ public sealed class PlayerPunchAnimator : MonoBehaviour
         return transform.localScale.x >= 0f;
     }
 
+    private Vector2 ResolveAimDirection(AttackRequest request)
+    {
+        Vector2 origin = aimOrigin != null ? (Vector2)aimOrigin.position : (Vector2)transform.position;
+        Vector2 delta = request.TargetPosition - origin;
+
+        if (delta.sqrMagnitude > 0.0001f)
+        {
+            return delta.normalized;
+        }
+
+        return ResolveFallbackDirection(request.Sector);
+    }
+
+    private Vector2 ResolveFallbackDirection(AttackSector sector)
+    {
+        switch (sector)
+        {
+            case AttackSector.Up:
+                return Vector2.up;
+            case AttackSector.Down:
+                return Vector2.down;
+            case AttackSector.Left:
+                return Vector2.left;
+            case AttackSector.Right:
+            default:
+                return Vector2.right;
+        }
+    }
+
+    private Vector2 ResolveDefaultAimDirection()
+    {
+        return IsFacingRight() ? Vector2.right : Vector2.left;
+    }
+
+    private void ApplyAimDirection(Vector2 aimDirection)
+    {
+        if (aimDirection.sqrMagnitude <= 0.0001f)
+        {
+            aimDirection = ResolveDefaultAimDirection();
+        }
+
+        if (masterRigRoot != null)
+        {
+            Vector3 target = new Vector3(aimDirection.x, aimDirection.y, 0f);
+            Quaternion rotation = Quaternion.FromToRotation(Vector3.right, target.normalized);
+            masterRigRoot.localRotation = masterRigBaseLocalRotation * rotation;
+        }
+
+        if (animator != null)
+        {
+            if (hasPunchAimXParameter)
+            {
+                animator.SetFloat(punchAimXHash, aimDirection.x);
+            }
+
+            if (hasPunchAimYParameter)
+            {
+                animator.SetFloat(punchAimYHash, aimDirection.y);
+            }
+        }
+    }
+
+    private void ResetAimState()
+    {
+        Vector2 resolvedDefault = ResolveDefaultAimDirection();
+        ApplyAimDirection(resolvedDefault);
+
+        if (animator != null)
+        {
+            animator.SetInteger(punchDirectionHash, idleDirectionValue);
+        }
+    }
+
+    private void CacheAnimatorParameters()
+    {
+        if (animator == null)
+        {
+            return;
+        }
+
+        punchDirectionHash = Animator.StringToHash(punchDirectionParameter);
+        punchTriggerHash = Animator.StringToHash(punchTriggerParameter);
+
+        hasPunchAimXParameter = TryResolveFloatParameter(punchAimXParameter, out punchAimXHash);
+        hasPunchAimYParameter = TryResolveFloatParameter(punchAimYParameter, out punchAimYHash);
+
+        animator.SetInteger(punchDirectionHash, idleDirectionValue);
+    }
+
+    private bool TryResolveFloatParameter(string parameterName, out int hash)
+    {
+        hash = 0;
+        if (animator == null || string.IsNullOrEmpty(parameterName))
+        {
+            return false;
+        }
+
+        AnimatorControllerParameter[] parameters = animator.parameters;
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            AnimatorControllerParameter parameter = parameters[i];
+            if (parameter.type == AnimatorControllerParameterType.Float &&
+                string.Equals(parameter.name, parameterName, StringComparison.Ordinal))
+            {
+                hash = Animator.StringToHash(parameterName);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public AttackSector CurrentAttackSector => currentAttackSector;
 
     public bool IsCurrentlyFacingRight => IsFacingRight();
@@ -117,7 +256,7 @@ public sealed class PlayerPunchAnimator : MonoBehaviour
         }
 
         animator.ResetTrigger(punchTriggerHash);
-        animator.SetInteger(punchDirectionHash, idleDirectionValue);
+        ResetAimState();
         currentAttackSector = AttackSector.Right;
         PunchCompleted?.Invoke();
     }
@@ -148,7 +287,7 @@ public sealed class PlayerPunchAnimator : MonoBehaviour
             }
         }
 
-        animator.SetInteger(punchDirectionHash, idleDirectionValue);
+        ResetAimState();
         punchRoutine = null;
         currentAttackSector = AttackSector.Right;
         PunchCompleted?.Invoke();
@@ -165,7 +304,7 @@ public sealed class PlayerPunchAnimator : MonoBehaviour
         if (animator != null)
         {
             animator.ResetTrigger(punchTriggerHash);
-            animator.SetInteger(punchDirectionHash, idleDirectionValue);
+            ResetAimState();
         }
 
         currentAttackSector = AttackSector.Right;

--- a/Assets/Scripts/Robots/RobotCombatController.cs
+++ b/Assets/Scripts/Robots/RobotCombatController.cs
@@ -27,6 +27,32 @@ public class RobotCombatController : MonoBehaviour
     /// </summary>
     public AttackRequestController AttackController => attackRequestController;
 
+    /// <summary>
+    /// Attempts to execute the provided <paramref name="request"/> using the
+    /// configured <see cref="AttackRequestController"/>.
+    /// </summary>
+    /// <param name="request">Requested attack details.</param>
+    /// <returns>True when the request was accepted.</returns>
+    public bool TryHandleAttack(AttackRequest request)
+    {
+        if (attackRequestController == null)
+        {
+            return false;
+        }
+
+        return attackRequestController.TryHandleAttack(request);
+    }
+
+    /// <summary>
+    /// Executes the provided <paramref name="request"/> disregarding the
+    /// success flag from <see cref="TryHandleAttack(AttackRequest)"/>.
+    /// </summary>
+    /// <param name="request">Requested attack details.</param>
+    public void HandleAttackRequest(AttackRequest request)
+    {
+        attackRequestController?.HandleAttackRequest(request);
+    }
+
     private void Awake()
     {
         if (robotStateController == null)


### PR DESCRIPTION
## Summary
- extend PlayerPunchAnimator to aim toward AttackRequest target positions and drive optional IK parameters
- propagate punch aim parameters through AttackRequestController for robots that use direct animator triggers
- expose helper methods on RobotCombatController so AI/boss logic can forward targeted attack requests

## Testing
- not run (Unity editor not available in container)

------
https://chatgpt.com/codex/tasks/task_e_6909f32963608324b489b894914086c0