### PR TITLE
Ensure enemy punch attacks arm hitboxes

### DIFF
--- a/Assets/Editor/UnitTests/EnemyPunchAttackTests.cs
+++ b/Assets/Editor/UnitTests/EnemyPunchAttackTests.cs
@@ -1,0 +1,90 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+
+public class EnemyPunchAttackTests
+{
+    [Test]
+    public void HandleAttackAccepted_ActivatesCorrectHorizontalHitbox()
+    {
+        GameObject enemy = new GameObject("Enemy");
+        enemy.SetActive(false);
+
+        enemy.AddComponent<EnergyBot>();
+        enemy.AddComponent<HealthBot>();
+        enemy.AddComponent<RobotStateController>();
+
+        EnemyPunchAttack punchAttack = enemy.AddComponent<EnemyPunchAttack>();
+        PunchHitboxEventRelay relay = enemy.AddComponent<PunchHitboxEventRelay>();
+
+        EnemyPunchAttack punchAttackInstance = punchAttack;
+        SetPrivateField(punchAttackInstance, "hitboxActiveDuration", 0f);
+
+        AttackHitbox leftHitbox = CreateHitbox(enemy.transform, "LeftHitbox");
+        AttackHitbox rightHitbox = CreateHitbox(enemy.transform, "RightHitbox");
+
+        SetRelayField(relay, "leftArmHitbox", leftHitbox);
+        SetRelayField(relay, "rightArmHitbox", rightHitbox);
+
+        enemy.transform.localScale = Vector3.one;
+        enemy.SetActive(true);
+
+        punchAttackInstance.HandleAttackAccepted(new AttackRequest(Vector2.zero, AttackSector.Right, 0f));
+
+        Assert.IsTrue(rightHitbox.IsActive, "Right hitbox should be armed when attacking to the right while facing right.");
+        Assert.IsFalse(leftHitbox.IsActive, "Left hitbox should remain inactive when attacking to the right.");
+
+        Object.DestroyImmediate(enemy);
+    }
+
+    [Test]
+    public void HandleAttackAccepted_RespectsFacingDirection()
+    {
+        GameObject enemy = new GameObject("EnemyFacingLeft");
+        enemy.SetActive(false);
+
+        enemy.AddComponent<EnergyBot>();
+        enemy.AddComponent<HealthBot>();
+        enemy.AddComponent<RobotStateController>();
+
+        EnemyPunchAttack punchAttack = enemy.AddComponent<EnemyPunchAttack>();
+        PunchHitboxEventRelay relay = enemy.AddComponent<PunchHitboxEventRelay>();
+
+        SetPrivateField(punchAttack, "hitboxActiveDuration", 0f);
+
+        AttackHitbox leftHitbox = CreateHitbox(enemy.transform, "LeftHitbox");
+        AttackHitbox rightHitbox = CreateHitbox(enemy.transform, "RightHitbox");
+
+        SetRelayField(relay, "leftArmHitbox", leftHitbox);
+        SetRelayField(relay, "rightArmHitbox", rightHitbox);
+
+        enemy.transform.localScale = new Vector3(-1f, 1f, 1f);
+        enemy.SetActive(true);
+
+        punchAttack.HandleAttackAccepted(new AttackRequest(Vector2.zero, AttackSector.Right, 0f));
+
+        Assert.IsTrue(leftHitbox.IsActive, "Left hitbox should be armed when facing left and attacking right.");
+        Assert.IsFalse(rightHitbox.IsActive, "Right hitbox should remain inactive when facing left and attacking right.");
+
+        Object.DestroyImmediate(enemy);
+    }
+
+    private static void SetPrivateField(object target, string fieldName, object value)
+    {
+        FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        field.SetValue(target, value);
+    }
+
+    private static void SetRelayField(PunchHitboxEventRelay relay, string fieldName, AttackHitbox hitbox)
+    {
+        FieldInfo field = typeof(PunchHitboxEventRelay).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        field.SetValue(relay, hitbox);
+    }
+
+    private static AttackHitbox CreateHitbox(Transform parent, string name)
+    {
+        GameObject go = new GameObject(name);
+        go.transform.SetParent(parent);
+        return go.AddComponent<AttackHitbox>();
+    }
+}

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyController.cs
@@ -196,7 +196,13 @@ public class EnemyController : AnimatorBaseAgentController, IPooledObject, IRobo
             return;
 
         if (TryBuildAttackRequest(out AttackRequest request))
-            attackRequestController.TryHandleAttack(request);
+        {
+            bool accepted = attackRequestController.TryHandleAttack(request);
+            if (accepted)
+            {
+                punchAttack?.HandleAttackAccepted(request);
+            }
+        }
     }
 
 

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyPunchAttack.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyPunchAttack.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 
 /// <summary>
@@ -11,11 +12,14 @@ public sealed class EnemyPunchAttack : MonoBehaviour
     [SerializeField] private float attackCooldown = 1f;
     [SerializeField] private float verticalSectorThreshold = 0.75f;
     [SerializeField] private FactoryAlarmStatus alarmStatus;
+    [SerializeField] private PunchHitboxEventRelay hitboxRelay;
+    [SerializeField] private float hitboxActiveDuration = 0.3f;
 
     private RobotStateController robotBehaviour;
     private RobotStats playerStats;
     private float lastPunchTime;
     private bool playerInAttackZone;
+    private Coroutine hitboxDeactivateRoutine;
 
     private void Awake()
     {
@@ -23,6 +27,15 @@ public sealed class EnemyPunchAttack : MonoBehaviour
         if (alarmStatus == null)
         {
             alarmStatus = FindFirstObjectByType<FactoryManager>()?.factoryAlarmStatus;
+        }
+
+        if (hitboxRelay == null)
+        {
+            hitboxRelay = GetComponent<PunchHitboxEventRelay>();
+            if (hitboxRelay == null)
+            {
+                hitboxRelay = GetComponentInChildren<PunchHitboxEventRelay>();
+            }
         }
     }
 
@@ -50,6 +63,14 @@ public sealed class EnemyPunchAttack : MonoBehaviour
         {
             targetToFollow.OnPlayerDetectInAttackZoneChanged -= HandlePlayerInAttackZoneChange;
         }
+
+        if (hitboxDeactivateRoutine != null)
+        {
+            StopCoroutine(hitboxDeactivateRoutine);
+            hitboxDeactivateRoutine = null;
+        }
+
+        hitboxRelay?.ForceDeactivateAllHitboxes();
     }
 
     private void HandlePlayerInAttackZoneChange(bool isInside)
@@ -88,6 +109,31 @@ public sealed class EnemyPunchAttack : MonoBehaviour
         return true;
     }
 
+    /// <summary>
+    /// Ensures the appropriate hitbox is armed when an attack is accepted.
+    /// </summary>
+    /// <param name="request">The attack request that was successfully issued.</param>
+    public void HandleAttackAccepted(AttackRequest request)
+    {
+        if (hitboxRelay == null)
+        {
+            return;
+        }
+
+        if (hitboxDeactivateRoutine != null)
+        {
+            StopCoroutine(hitboxDeactivateRoutine);
+            hitboxDeactivateRoutine = null;
+        }
+
+        hitboxRelay.ActivateHitboxForRequest(request);
+
+        if (hitboxActiveDuration > 0f)
+        {
+            hitboxDeactivateRoutine = StartCoroutine(DeactivateHitboxAfterDelay(hitboxActiveDuration));
+        }
+    }
+
     private bool CanIssueAttack()
     {
         if (targetToFollow == null || !playerInAttackZone)
@@ -117,5 +163,12 @@ public sealed class EnemyPunchAttack : MonoBehaviour
         }
 
         return delta.x >= 0f ? AttackSector.Right : AttackSector.Left;
+    }
+
+    private IEnumerator DeactivateHitboxAfterDelay(float delay)
+    {
+        yield return new WaitForSeconds(delay);
+        hitboxRelay?.ForceDeactivateAllHitboxes();
+        hitboxDeactivateRoutine = null;
     }
 }

--- a/Assets/Scripts/Player/Controllers/PunchHitboxEventRelay.cs
+++ b/Assets/Scripts/Player/Controllers/PunchHitboxEventRelay.cs
@@ -83,6 +83,15 @@ public sealed class PunchHitboxEventRelay : MonoBehaviour
     }
 
     /// <summary>
+    /// Activates the hitbox that matches the provided <paramref name="request"/>.
+    /// </summary>
+    /// <param name="request">Details about the attack that should arm a hitbox.</param>
+    public void ActivateHitboxForRequest(AttackRequest request)
+    {
+        ActivateHitbox(ResolveHitboxForSector(request.Sector, ResolveFacingDirection()));
+    }
+
+    /// <summary>
     /// Deactivates the hitbox associated with the currently playing punch.
     /// </summary>
     public void DeactivatePrimaryHitbox()
@@ -172,12 +181,11 @@ public sealed class PunchHitboxEventRelay : MonoBehaviour
     private AttackHitbox ResolveHitboxForCurrentSector()
     {
         AttackSector sector = punchAnimator != null ? punchAnimator.CurrentAttackSector : AttackSector.Right;
-        bool facingRight = punchAnimator != null
-            ? punchAnimator.IsCurrentlyFacingRight
-            : (robotStateController != null
-                ? robotStateController.transform.localScale.x >= 0f
-                : transform.lossyScale.x >= 0f);
+        return ResolveHitboxForSector(sector, ResolveFacingDirection());
+    }
 
+    private AttackHitbox ResolveHitboxForSector(AttackSector sector, bool facingRight)
+    {
         switch (sector)
         {
             case AttackSector.Up:
@@ -190,6 +198,21 @@ public sealed class PunchHitboxEventRelay : MonoBehaviour
             default:
                 return facingRight ? rightArmHitbox : leftArmHitbox;
         }
+    }
+
+    private bool ResolveFacingDirection()
+    {
+        if (punchAnimator != null)
+        {
+            return punchAnimator.IsCurrentlyFacingRight;
+        }
+
+        if (robotStateController != null)
+        {
+            return robotStateController.transform.localScale.x >= 0f;
+        }
+
+        return transform.lossyScale.x >= 0f;
     }
 
     private AttackHitbox SelectHorizontalHitbox(bool facingRight)


### PR DESCRIPTION
## Summary
- activate enemy punch hitboxes when an attack request is accepted and auto-deactivate them after a short delay
- extend the punch hitbox relay to resolve hitboxes directly from attack requests
- update the enemy controller to notify the punch attack component when an attack begins
- add edit-mode tests covering the hitbox arming logic for facing directions

## Testing
- Not run (Unity CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6909fc8275348324bd27f61f24eefbe6