### PR TITLE
Fix enemy punch cooldown reset timing

### DIFF
--- a/Assets/Scripts/EnemyAI/Controllers/EnemyPunchAttack.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyPunchAttack.cs
@@ -105,7 +105,6 @@ public sealed class EnemyPunchAttack : MonoBehaviour
 
         Vector2 targetPosition = new Vector2(playerPosition.x, playerPosition.y);
         request = new AttackRequest(targetPosition, sector, energyCost);
-        lastPunchTime = Time.time;
         return true;
     }
 
@@ -119,6 +118,8 @@ public sealed class EnemyPunchAttack : MonoBehaviour
         {
             return;
         }
+
+        lastPunchTime = Time.time;
 
         if (hitboxDeactivateRoutine != null)
         {


### PR DESCRIPTION
## Summary
- ensure enemy punch cooldown timestamps update only when an attack request is accepted
- move the cooldown update into the accepted handler so failed requests do not delay retries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6907d1bd8db08324989d71f9f0e29dcc