### PR TITLE
Prevent animator-only robots from getting stuck after attacks

### DIFF
--- a/Assets/Scripts/Combat/AttackRequestController.cs
+++ b/Assets/Scripts/Combat/AttackRequestController.cs
@@ -117,7 +117,7 @@ public sealed class AttackRequestController : MonoBehaviour
     /// <returns>True when the request was accepted.</returns>
     public bool TryHandleAttack(AttackRequest request)
     {
-        if (attackInProgress)
+        if (ShouldBlockNewRequest())
         {
             return false;
         }
@@ -135,7 +135,10 @@ public sealed class AttackRequestController : MonoBehaviour
         }
 
         TriggerAnimation(request);
-        attackInProgress = true;
+        if (ShouldTrackAttackProgress())
+        {
+            attackInProgress = true;
+        }
         return true;
     }
 
@@ -176,6 +179,21 @@ public sealed class AttackRequestController : MonoBehaviour
     public void NotifyPunchCompleted()
     {
         attackInProgress = false;
+    }
+
+    private bool ShouldBlockNewRequest()
+    {
+        if (!ShouldTrackAttackProgress())
+        {
+            return false;
+        }
+
+        return attackInProgress;
+    }
+
+    private bool ShouldTrackAttackProgress()
+    {
+        return punchAnimator != null;
     }
 
     private bool ConsumeEnergy(AttackRequest request)

--- a/Assets/Scripts/EnemyAI/Controllers/EnemyPunchAttack.cs
+++ b/Assets/Scripts/EnemyAI/Controllers/EnemyPunchAttack.cs
@@ -105,7 +105,6 @@ public sealed class EnemyPunchAttack : MonoBehaviour
 
         Vector2 targetPosition = new Vector2(playerPosition.x, playerPosition.y);
         request = new AttackRequest(targetPosition, sector, energyCost);
-        lastPunchTime = Time.time;
         return true;
     }
 
@@ -119,6 +118,8 @@ public sealed class EnemyPunchAttack : MonoBehaviour
         {
             return;
         }
+
+        lastPunchTime = Time.time;
 
         if (hitboxDeactivateRoutine != null)
         {


### PR DESCRIPTION
## Summary
- avoid blocking subsequent attack requests when no PlayerPunchAnimator is present by skipping progress tracking
- centralize the attack progress gating logic inside helper methods for clarity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6907d1bd8db08324989d71f9f0e29dcc