### PR TITLE
Remove redundant hitbox cleanup on energy failure

### DIFF
--- a/Assets/Scripts/Combat/AttackRequestController.cs
+++ b/Assets/Scripts/Combat/AttackRequestController.cs
@@ -123,7 +123,6 @@ public sealed class AttackRequestController : MonoBehaviour
 
         if (!ConsumeEnergy(request))
         {
-            hitboxRelay?.ForceDeactivateAllHitboxes();
             AbortActiveAttack();
             return false;
         }


### PR DESCRIPTION
## Summary
- remove the redundant hitbox deactivation in `AttackRequestController`
- rely on `AbortActiveAttack` to perform hitbox cleanup when energy checks fail

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690a3a6051608324be09cdb018f49787