### PR TITLE
End attack motion when hit lands

### DIFF
--- a/Assets/Scripts/Robots/ArmTargetController.cs
+++ b/Assets/Scripts/Robots/ArmTargetController.cs
@@ -35,6 +35,7 @@ public class CowboyArmTargetController : MonoBehaviour
     private bool interactReleasedThisFrame;
     private bool attackHeld;
     private bool attackInputHeld;
+    private bool attackSuppressedUntilRelease;
     private bool preferRightArm = true;
     private CowboyArmSide? attackActiveArm;
 
@@ -59,6 +60,7 @@ public class CowboyArmTargetController : MonoBehaviour
         CacheControllers();
         CacheRestPose();
         attackController?.DeactivateAll();
+        SubscribeToAttackEvents();
     }
 
     private void OnDisable()
@@ -68,9 +70,11 @@ public class CowboyArmTargetController : MonoBehaviour
         interactReleasedThisFrame = false;
         attackHeld = false;
         attackInputHeld = false;
+        attackSuppressedUntilRelease = false;
         attackActiveArm = null;
         attackController?.DeactivateAll();
         grabController?.ReleaseAllImmediate();
+        UnsubscribeFromAttackEvents();
     }
 
     private void Update()
@@ -79,7 +83,12 @@ public class CowboyArmTargetController : MonoBehaviour
         bool attackInput = IsLeftMouseHeld();
 
         attackInputHeld = attackInput;
-        attackHeld = allowAttackAim && attackInputHeld;
+        if (!attackInputHeld)
+        {
+            attackSuppressedUntilRelease = false;
+        }
+
+        attackHeld = allowAttackAim && attackInputHeld && !attackSuppressedUntilRelease;
 
         interactPressedThisFrame = !interactHeld && currentlyHeld;
         interactReleasedThisFrame = interactHeld && !currentlyHeld;
@@ -128,6 +137,23 @@ public class CowboyArmTargetController : MonoBehaviour
         if (attackController == null)
         {
             attackController = GetComponentInParent<CowboySimpleAttackController>();
+        }
+    }
+
+    private void SubscribeToAttackEvents()
+    {
+        UnsubscribeFromAttackEvents();
+        if (attackController != null)
+        {
+            attackController.AttackHit += OnAttackHit;
+        }
+    }
+
+    private void UnsubscribeFromAttackEvents()
+    {
+        if (attackController != null)
+        {
+            attackController.AttackHit -= OnAttackHit;
         }
     }
 
@@ -215,6 +241,17 @@ public class CowboyArmTargetController : MonoBehaviour
             return;
         }
 
+        if (attackSuppressedUntilRelease)
+        {
+            if (attackActiveArm.HasValue)
+            {
+                attackController.SetArmAttackActive(attackActiveArm.Value, false);
+                attackActiveArm = null;
+            }
+
+            return;
+        }
+
         if (!attackInputHeld)
         {
             if (attackActiveArm.HasValue)
@@ -243,6 +280,22 @@ public class CowboyArmTargetController : MonoBehaviour
         attackController.SetArmAttackActive(attackActiveArm.Value, false);
         attackController.SetArmAttackActive(desiredArm, true);
         attackActiveArm = desiredArm;
+    }
+
+    private void OnAttackHit(CowboyArmSide arm)
+    {
+        attackSuppressedUntilRelease = true;
+        attackHeld = false;
+
+        if (attackController != null)
+        {
+            attackController.SetArmAttackActive(arm, false);
+        }
+
+        if (attackActiveArm.HasValue)
+        {
+            attackActiveArm = null;
+        }
     }
 
 

--- a/Assets/Scripts/Robots/AttackHitbox.cs
+++ b/Assets/Scripts/Robots/AttackHitbox.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 public class AttackHitbox : MonoBehaviour
@@ -11,6 +12,8 @@ public class AttackHitbox : MonoBehaviour
     public int DamageCost = 5;
     private bool isActive = false;
     private RobotStateController attacker;
+
+    public event Action<AttackHitbox> Hit;
 
     private void Awake()
     {
@@ -68,6 +71,7 @@ public class AttackHitbox : MonoBehaviour
 
         isActive = false;
         UpdateIndicator(false);
+        Hit?.Invoke(this);
     }
 
     private void UpdateIndicator(bool active)

--- a/Assets/Scripts/Robots/SimpleAttackController.cs
+++ b/Assets/Scripts/Robots/SimpleAttackController.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 /// <summary>
@@ -11,15 +12,19 @@ public class CowboySimpleAttackController : MonoBehaviour
     [SerializeField] private AttackHitbox rightHandHitbox;
     private bool referencesLogged;
 
+    public event Action<CowboyArmSide> AttackHit;
+
     private void OnEnable()
     {
         DeactivateAll();
         LogMissingReferences();
+        SubscribeToHitboxes();
     }
 
     private void OnDisable()
     {
         DeactivateAll();
+        UnsubscribeFromHitboxes();
     }
 
     public void SetArmAttackActive(CowboyArmSide arm, bool active)
@@ -54,6 +59,33 @@ public class CowboySimpleAttackController : MonoBehaviour
         referencesLogged = true;
     }
 
+    private void SubscribeToHitboxes()
+    {
+        UnsubscribeFromHitboxes();
+        if (leftHandHitbox != null)
+        {
+            leftHandHitbox.Hit += OnHitboxHit;
+        }
+
+        if (rightHandHitbox != null)
+        {
+            rightHandHitbox.Hit += OnHitboxHit;
+        }
+    }
+
+    private void UnsubscribeFromHitboxes()
+    {
+        if (leftHandHitbox != null)
+        {
+            leftHandHitbox.Hit -= OnHitboxHit;
+        }
+
+        if (rightHandHitbox != null)
+        {
+            rightHandHitbox.Hit -= OnHitboxHit;
+        }
+    }
+
     private void ActivateArm(CowboyArmSide arm)
     {
         AttackHitbox hitbox = GetHitbox(arm);
@@ -69,5 +101,36 @@ public class CowboySimpleAttackController : MonoBehaviour
     private AttackHitbox GetHitbox(CowboyArmSide arm)
     {
         return arm == CowboyArmSide.Right ? rightHandHitbox : leftHandHitbox;
+    }
+
+    private void OnHitboxHit(AttackHitbox hitbox)
+    {
+        CowboyArmSide? arm = GetArmForHitbox(hitbox);
+        if (!arm.HasValue)
+        {
+            return;
+        }
+
+        AttackHit?.Invoke(arm.Value);
+    }
+
+    private CowboyArmSide? GetArmForHitbox(AttackHitbox hitbox)
+    {
+        if (hitbox == null)
+        {
+            return null;
+        }
+
+        if (hitbox == leftHandHitbox)
+        {
+            return CowboyArmSide.Left;
+        }
+
+        if (hitbox == rightHandHitbox)
+        {
+            return CowboyArmSide.Right;
+        }
+
+        return null;
     }
 }

--- a/Docs/cowboy_attack_investigation.md
+++ b/Docs/cowboy_attack_investigation.md
@@ -1,0 +1,17 @@
+# Cowboy player attack flow investigation
+
+This note tracks where the cowboy player's arm movement and basic attack state are driven, to prepare a change where the attack motion should also end when a hit lands (instead of only when the player releases left click).
+
+## Arm input and solver steering
+- `CowboyArmTargetController` watches mouse buttons each `Update()`. Holding left click sets `attackInputHeld`/`attackHeld`, while releasing left click clears them and immediately deactivates any active attack arm via `CowboySimpleAttackController.SetArmAttackActive(...)`. The same class moves the IK solver targets in `LateUpdate()` whenever `interactHeld` (right click) or `attackHeld` (left click) is true, and returns the arms to their rest pose when both are false. Relevant logic:
+  - Input capture and attack state toggling: `Update()` and `HandleAttackInput()` lines 76-245.
+  - IK target driving based on `attackHeld`/`interactHeld`: `LateUpdate()` lines 249-301, plus helper methods for arm selection and rest return.
+
+## Hitbox activation and auto-shutdown
+- `CowboySimpleAttackController` only enables/disables the per-arm `AttackHitbox` instances based on the chosen active arm. It deactivates both hitboxes when disabled and when switching arms; this is currently triggered only by the left-click state changes above.
+- `AttackHitbox` itself turns off once it registers a collision in `OnTriggerEnter2D`, after applying damage and pushback. This means a landed hit already deactivates the hitbox, but the arm target keeps moving until the player releases left click because `CowboyArmTargetController` does not react to hitbox events.
+
+## Likely integration points to end motion on hit
+- Introduce a notification from `AttackHitbox` when it deactivates after a hit, so the controller driving arm motion can react. Options include a UnityEvent/Action on `AttackHitbox` or having `CowboySimpleAttackController` poll `AttackHitbox.IsActive` each frame.
+- In `CowboyArmTargetController`, consume that notification (or poll state) to clear `attackHeld`/`attackActiveArm` and call `SetArmAttackActive(..., false)` so the arm stops following the target and returns to rest even if the mouse button remains pressed.
+- Any change should consider the existing arm-selection logic in `HandleAttackInput()` and the rest return path in `LateUpdate()` to ensure the arms reset correctly when a hit ends the attack.


### PR DESCRIPTION
## Summary
- add hit notifications from attack hitboxes and forward them through the simple attack controller
- stop arm-driven attack motion when a hit occurs until the player releases the attack input
- ensure attack hit subscriptions clean up and suppress stale arm activation after a hit

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922fc32dd8483249b782a411474b2f8)